### PR TITLE
Make the app deployable to GitHub Pages and the top chrome responsive

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,6 +60,15 @@ OPENSKY_CLIENT_SECRET=
 # Optional: OpenSky credentials JSON file path (alternative to above)
 # OPENSKY_CREDENTIALS_FILE=/path/to/credentials.json
 
+# Optional: static-hosting flag. A BUILD has no /api middleware — every proxy
+# is registered through Vite's configureServer hook, so it runs under
+# `vite dev` only (`vite preview` has none either). Builds therefore default to
+# static mode: /api calls are answered locally with an explanatory 503 and the
+# app shows a one-time notice about which layers need the dev server.
+# Set to 0 ONLY when serving dist/ behind something that actually implements
+# the same /api surface. Ignored by `npm run dev`. See docs/GITHUB-PAGES.md.
+# GEV_STATIC_BUILD=0
+
 # Optional: dev server config
 PORT=4173
 # Network binding. Default is localhost — the server is reachable ONLY from

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,90 @@
+name: Deploy to GitHub Pages
+
+# Publishes the static build to GitHub Pages.
+#
+# What you get: the 3D globe, every visual style, the camera/scene director,
+# share links, annotations, the bundled datasets, and the feeds that are
+# CORS-open straight from the browser (USGS earthquakes, GBFS bikeshare).
+#
+# What you do NOT get: the live intelligence feeds. Those are brokered by proxy
+# middleware in vite.config.js that only runs under `vite dev`, because it holds
+# the server-side keys. The app detects this and says so in-page rather than
+# failing quietly. See docs/GITHUB-PAGES.md.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# Least privilege: read the tree, mint the Pages deployment, nothing else.
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Never let two deployments race; let an in-flight one finish rather than
+# cancelling it half-published.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          # Matches the engines range in package.json.
+          node-version: '24'
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm test
+
+      - name: Build
+        # BROWSER-EXPOSED BY DESIGN. Both keys are used client-side, so they end
+        # up in the bundle and are visible in devtools — that is true of every
+        # deployment, not just this one. Restrict them at the provider instead
+        # (HTTP referrer + API restriction for Google; a public assets:read
+        # token with URL restrictions for Cesium ion). See SECURITY.md.
+        #
+        # Both are OPTIONAL: with neither set the site still builds and runs on
+        # the keyless OpenStreetMap globe, and visitors can supply their own
+        # keys from the in-app notice. Add them under
+        # Settings → Secrets and variables → Actions to publish a
+        # photorealistic deployment.
+        env:
+          GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
+          CESIUM_ION_TOKEN: ${{ secrets.CESIUM_ION_TOKEN }}
+        run: npm run build
+
+      - name: Add SPA/404 fallback
+        # Pages serves 404.html for any unknown path. The app is a single page
+        # whose state lives in the query string, so serving the same document
+        # keeps a mistyped or stale deep link on the globe instead of GitHub's
+        # 404. Asset URLs are relative, so this works from any sub-path.
+        run: cp dist/index.html dist/404.html
+
+      - name: Skip Jekyll
+        # Without this, Pages runs the tree through Jekyll, which drops files
+        # and directories beginning with an underscore.
+        run: touch dist/.nojekyll
+
+      - uses: actions/configure-pages@v5
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -77,6 +77,14 @@ The dev server binds to **localhost** — your keys stay on your machine. Sharin
 
 **macOS shortcut:** `./scripts/dev-fresh.sh` clears the Vite cache and pulls your keys straight from the Keychain.
 
+**No install? Publish it instead.** `npm run build` produces a static `dist/`
+that runs from any host and any URL prefix, and the repo ships a GitHub Pages
+workflow. You get the globe, every visual style, share links, the bundled
+datasets, and the CORS-open feeds (earthquakes, bikeshare) — with or without an
+API key. The live intelligence feeds still need the dev server, because their
+proxies are what keep those keys off the client. Full split and setup in
+[docs/GITHUB-PAGES.md](docs/GITHUB-PAGES.md).
+
 ---
 
 ## 🕐 The First Five Minutes
@@ -322,6 +330,20 @@ Honest numbers, roughly, as of mid-2026 — always check the provider pricing pa
 ### 🧗 The floor is low on purpose
 
 Everything above is the deliberately cheap baseline — enough to get a real taste of geospatial intelligence, GEOINT, and OSINT without ever talking to a sales team. You'll also notice the ceiling: terrestrial AIS goes quiet mid-ocean and satellite AIS costs real money; premium imagery, SAR, and the deeper commercial feeds live behind enterprise contracts. That's not a limit of the architecture — every layer here is a pattern you can point at your own data sources. This repo hands you the foundation; what you fuse into it is up to you.
+
+### 🌐 Publishing a static instance
+
+A built `dist/` is safe to publish in a way a dev server is not: the proxies —
+and every server-side key they hold — simply are not in it. What ships is the
+app plus the two keys that are *meant* to be client-side (Google Maps, Cesium
+ion), and those are visible in devtools on any deployment, local included.
+
+The exposure that remains is **quota**: a public URL means anyone who loads it
+spends yours. Restrict the Google key by HTTP referrer and API, use a
+URL-restricted `assets:read` token for Cesium ion, and set provider-side budget
+caps before you share the link. Or publish with no keys at all — the site runs
+on the OpenStreetMap globe and lets each visitor supply their own.
+See [docs/GITHUB-PAGES.md](docs/GITHUB-PAGES.md).
 
 ### 🔒 Sharing an instance
 

--- a/docs/GITHUB-PAGES.md
+++ b/docs/GITHUB-PAGES.md
@@ -1,0 +1,134 @@
+# Hosting on GitHub Pages
+
+God's Eye View can be published as a static site. This page explains what a
+static deployment can and cannot do, how to set one up, and why the split falls
+where it does.
+
+---
+
+## The one thing to understand first
+
+Every **live** feed in this app is brokered by proxy middleware that lives in
+`vite.config.js`. That middleware is registered through Vite's `configureServer`
+hook, which means it runs under **`vite dev` and nowhere else** — not in a
+build, and not under `vite preview` either.
+
+That design is deliberate and it is the reason the app is safe to run: the
+proxies hold the server-side keys (OpenSky, TomTom, FIRMS, AISStream, OpenAI…)
+so those keys never reach a browser. See [SECURITY.md](../SECURITY.md).
+
+A static host serves files. It cannot run that middleware, so `/api/*` does not
+exist there. That is a property of static hosting, not a bug to fix — and it is
+not a reason to skip deploying, because a large part of the app never needed a
+backend at all.
+
+---
+
+## What works on Pages
+
+🟢 **No key, no server, works immediately**
+
+- the 3D globe, all visual styles, the camera and scene director
+- share links, annotations, the measurement and framing tools
+- the bundled datasets: submarine cables, data centres, dams, regions
+- **earthquakes** (USGS) and **bikeshare** (GBFS) — both CORS-open, fetched
+  straight from source by the browser
+
+🔴 **With `GOOGLE_MAPS_API_KEY`**
+
+- Google Photorealistic 3D Tiles — the photorealistic planet
+- geocoding, place context, and the location search
+
+🟡 **With `CESIUM_ION_TOKEN`**
+
+- the Bing aerial basemap stacks and Cesium World Terrain
+
+## What needs the local dev server
+
+These poll `/api/*`, so they are unavailable on a static host:
+
+- aircraft, military flights, satellites, rocket launches, active fires
+- street traffic, CCTV, radio, live vessels, military installations
+- voice control
+
+The app does not leave you guessing about this. A static build:
+
+- answers its own `/api/*` calls with an explanatory 503, so each layer's normal
+  status line reads *"Live feed needs the local server"* instead of choking on
+  the host's 404 HTML page;
+- shows a one-time notice on first visit listing both halves of the split.
+
+To get the live feeds, clone and run locally — see [Quick Start](../README.md#-quick-start).
+
+---
+
+## Deploying
+
+The workflow at [`.github/workflows/deploy-pages.yml`](../.github/workflows/deploy-pages.yml)
+does the whole job. On your fork:
+
+1. **Settings → Pages → Build and deployment → Source: GitHub Actions.**
+2. *(Optional, for the photorealistic globe)* **Settings → Secrets and variables
+   → Actions → New repository secret**, and add either or both of:
+   - `GOOGLE_MAPS_API_KEY` — Map Tiles API enabled
+   - `CESIUM_ION_TOKEN` — a public `assets:read` token
+3. Push to `main`, or run the workflow manually from the **Actions** tab.
+
+The site lands at `https://<user>.github.io/<repo>/`.
+
+### About those two keys
+
+Both are **exposed to the browser by design** — they are used client-side, so
+they appear in the bundle and in devtools. That is true of any deployment of
+this app, local included. Restrict them at the provider rather than trying to
+hide them:
+
+- **Google:** an HTTP referrer restriction scoped to your Pages origin, plus an
+  API restriction to the Map Tiles API. Set a quota and a budget alert.
+- **Cesium ion:** a token with only `assets:read`, URL-restricted.
+
+A public deployment is reachable by anyone, so **anyone who loads the page spends
+your quota.** Referrer restrictions and provider-side budget caps are the
+controls that matter here; treat them as required, not optional.
+
+Every other key in `.env.example` stays server-side and is never read by a
+build. Do not add them as Actions secrets — the build has no use for them.
+
+### Letting visitors bring their own keys
+
+The first-visit notice has fields for the Google key and the Cesium ion token. A
+value entered there is kept in that browser's `localStorage` and takes
+precedence over anything baked in at build time.
+
+That makes a keyless deployment genuinely useful: publish it with no secrets at
+all, and anyone who wants the photorealistic globe can point it at their own
+quota without forking or rebuilding.
+
+---
+
+## Hosting somewhere else
+
+Nothing here is Pages-specific. `npm run build` produces a `dist/` that works
+from any static host and from any URL prefix — asset URLs are relative, so
+`https://example.com/`, `https://example.com/gev/` and a plain file server all
+work from the same artifact.
+
+Two things the Pages workflow adds that you may want to replicate:
+
+- `dist/404.html` as a copy of `index.html`, so deep links survive;
+- `dist/.nojekyll`, which only matters on Pages.
+
+### If you put a real backend behind it
+
+If you serve `dist/` behind something that implements the same `/api` surface —
+your own proxy, a Cloudflare Worker, a small Express app — build with
+`GEV_STATIC_BUILD=0`. That drops the 503 stub and the notice, and the layers
+poll normally.
+
+```bash
+GEV_STATIC_BUILD=0 npm run build
+```
+
+Reimplementing that surface is not a small job: the middleware in
+`vite.config.js` handles auth, caching, rate limits, SSRF guards and response
+sanitisation for each upstream. Read it before you copy it.

--- a/src/appAssetUrl.js
+++ b/src/appAssetUrl.js
@@ -1,0 +1,52 @@
+/**
+ * Root-relative asset paths, resolved against wherever the app was published.
+ *
+ * Source keeps writing `/models/airplane.glb` and `/logo.svg` — those strings
+ * are identity keys in several registries (and are pinned by unit tests), so
+ * they must stay stable. What changes is the moment the string becomes a URL:
+ * a build served from a sub-path (a GitHub Pages *project* site lives at
+ * `https://<user>.github.io/<repo>/`) would 404 on a leading `/`, because that
+ * resolves to the domain root rather than the app root.
+ *
+ * Vite rewrites the references it can see itself — `<img src>` in index.html,
+ * `url()` in CSS, anything imported through the module graph. It cannot see a
+ * path assembled at runtime, which is what this helper covers.
+ */
+
+/**
+ * The directory the current document was served from, always with a trailing
+ * slash: `/` at a domain root, `/gods-eye-view/` on a Pages project site.
+ *
+ * `document.baseURI` (not `location.href`) so an explicit `<base href>` wins,
+ * and so a deep link with a query string or hash still resolves to the folder.
+ */
+const APP_BASE = (() => {
+  if (typeof document === 'undefined') return '/';
+  try {
+    return new URL('.', document.baseURI).pathname || '/';
+  } catch {
+    return '/';
+  }
+})();
+
+/** Already-absolute forms that must be handed through untouched. */
+const ABSOLUTE_URL = /^(?:[a-z][a-z0-9+.-]*:|\/\/)/i;
+
+/**
+ * Resolve an app-relative asset path for the current deployment.
+ *
+ * @param {string} path Root-relative path (`/models/jet.glb`) or absolute URL.
+ * @returns {string} A URL valid from the document, or `path` unchanged when it
+ *   is already absolute (http:, data:, blob:, protocol-relative) or not a
+ *   non-empty string.
+ */
+export function appAssetUrl(path) {
+  if (typeof path !== 'string' || path === '') return path;
+  if (ABSOLUTE_URL.test(path)) return path;
+  return APP_BASE + path.replace(/^\/+/, '');
+}
+
+/** The resolved app root, exported for callers that build their own URLs. */
+export function appBaseUrl() {
+  return APP_BASE;
+}

--- a/src/data/flights.js
+++ b/src/data/flights.js
@@ -21,6 +21,7 @@
  */
 import * as Cesium from 'cesium';
 import { aircraftIncludedInNearby } from './aircraftNearbyPolicy.js';
+import { appAssetUrl } from '../appAssetUrl.js';
 import { registerPickOwner, unregisterPickOwner, isOwnedByOtherLayer, resolvePickId } from './pickRegistry.js';
 import {
   registerSpriteCollection,
@@ -2415,7 +2416,7 @@ async function _ensureModel(icao24) {
   try {
     const spec = _modelSpec(_flightData.get(icao24)?.klass);
     model = await Cesium.Model.fromGltfAsync({
-      url: spec.url,
+      url: appAssetUrl(spec.url),
       asynchronous: false,
       minimumPixelSize: MODEL_MIN_PX,
       scale: spec.scale,
@@ -2538,7 +2539,7 @@ function _updateTrackedModel() {
     const trackedKey = _specKeyFor(_flightData.get(_trackedIcao)?.klass);
     const trackedIrBoost = _irBoost;
     Cesium.Model.fromGltfAsync({
-      url: trackedSpec.url,
+      url: appAssetUrl(trackedSpec.url),
       asynchronous: false,
       minimumPixelSize: TRACKED_MODEL_MIN_PX,
       scale: trackedSpec.scale,
@@ -3915,7 +3916,7 @@ const flightsLayer = {
     // destroy/re-init mid-load doesn't flip the flag for a torn-down lifecycle.
     if (!_preloadModel) {
       const epoch = _modelEpoch;
-      Cesium.Model.fromGltfAsync({ url: PLANE_MODEL_URL, asynchronous: false })
+      Cesium.Model.fromGltfAsync({ url: appAssetUrl(PLANE_MODEL_URL), asynchronous: false })
         .then((m) => {
           if (epoch === _modelEpoch) { _preloadModel = m; _planeModelLoaded = true; }
           else { try { m.destroy(); } catch { /* gone */ } }

--- a/src/data/militaryFlights.js
+++ b/src/data/militaryFlights.js
@@ -1,5 +1,6 @@
 import * as Cesium from 'cesium';
 import { aircraftIncludedInNearby } from './aircraftNearbyPolicy.js';
+import { appAssetUrl } from '../appAssetUrl.js';
 import { registerPickOwner, unregisterPickOwner, isOwnedByOtherLayer, resolvePickId } from './pickRegistry.js';
 import { registerSpriteCollection, restoreSpriteOrder } from './spriteOrder.js';
 import {
@@ -1593,7 +1594,7 @@ async function _ensureModel(icao24) {
   try {
     const spec = _modelSpec(_flightData.get(icao24)?.klass);
     model = await Cesium.Model.fromGltfAsync({
-      url: spec.url,
+      url: appAssetUrl(spec.url),
       asynchronous: false,
       minimumPixelSize: MODEL_MIN_PX,
       scale: spec.scale,
@@ -1713,7 +1714,7 @@ function _updateTrackedModel() {
     const trackedKey = _specKeyFor(_flightData.get(_trackedIcao)?.klass);
     const trackedIrBoost = _irBoost;
     Cesium.Model.fromGltfAsync({
-      url: trackedSpec.url,
+      url: appAssetUrl(trackedSpec.url),
       asynchronous: false,
       minimumPixelSize: TRACKED_MODEL_MIN_PX,
       scale: trackedSpec.scale,
@@ -2625,7 +2626,7 @@ const militaryFlightsLayer = {
     // destroy/re-init mid-load doesn't flip the flag for a torn-down lifecycle.
     if (!_preloadModel) {
       const epoch = _modelEpoch;
-      Cesium.Model.fromGltfAsync({ url: JET_MODEL_URL, asynchronous: false })
+      Cesium.Model.fromGltfAsync({ url: appAssetUrl(JET_MODEL_URL), asynchronous: false })
         .then((m) => {
           if (epoch === _modelEpoch) { _preloadModel = m; _planeModelLoaded = true; }
           else { try { m.destroy(); } catch { /* gone */ } }

--- a/src/logoGaze.js
+++ b/src/logoGaze.js
@@ -1,3 +1,4 @@
+import { appAssetUrl } from './appAssetUrl.js';
 const MAX_GAZE_SVG_UNITS = 34;
 const FULL_GAZE_DISTANCE_PX = 320;
 const GAZE_EASING = 0.2;
@@ -88,7 +89,7 @@ export function initLogoGaze(root = document) {
 
   const loadInlineLogos = async () => {
     try {
-      const source = logos[0].dataset.logoSrc || '/logo.svg';
+      const source = appAssetUrl(logos[0].dataset.logoSrc || '/logo.svg');
       const response = await window.fetch(source);
       if (!response.ok) return;
       const markup = await response.text();

--- a/src/main.js
+++ b/src/main.js
@@ -32,6 +32,15 @@ import {
 } from './renderGovernor.js';
 import { installScopeMask } from './scopeMask.js';
 import { initFirstRunExperience } from './firstRunExperience.js';
+import {
+  installStaticApiStub,
+  readClientCredential,
+  showStaticDeploymentNotice,
+} from './staticDeployment.js';
+
+// Before any layer can poll: on a static host there is no /api middleware, so
+// answer those calls with an explanatory 503 instead of the host's 404 page.
+installStaticApiStub();
 
 initLogoGaze();
 
@@ -73,21 +82,30 @@ async function init() {
   try {
     loaderStatus.textContent = 'Configuring viewer...';
 
-    // Set Cesium Ion token for World Terrain
-    const cesiumToken = import.meta.env.CESIUM_ION_TOKEN;
+    // Set Cesium Ion token for World Terrain. Build-time value, or one the
+    // visitor supplied on a static deployment (see staticDeployment.js).
+    const cesiumToken = readClientCredential('CESIUM_ION_TOKEN');
     if (cesiumToken) {
       Cesium.Ion.defaultAccessToken = cesiumToken;
     }
 
-    // Set Google Maps API key for 3D Tiles
-    const googleApiKey = import.meta.env.GOOGLE_MAPS_API_KEY;
-    if (!googleApiKey) {
-      throw new Error('GOOGLE_MAPS_API_KEY not found. Set it as an environment variable.');
+    // Google Maps API key for the photorealistic 3D Tiles. OPTIONAL: without
+    // it the app used to abort here, which made every keyless deployment look
+    // broken even though MapStackController already falls back to the keyless
+    // OpenStreetMap stack when there is no Google tileset. Boot on OSM instead
+    // and say why — a globe you can fly is a far better failure mode than an
+    // error string on a black screen.
+    const googleApiKey = readClientCredential('GOOGLE_MAPS_API_KEY');
+    if (googleApiKey) {
+      Cesium.GoogleMaps.defaultApiKey = googleApiKey;
+      // Expose API key globally for geocoding in locations.js
+      window.__GOOGLE_MAPS_API_KEY__ = googleApiKey;
+    } else {
+      console.warn(
+        '[Init] No GOOGLE_MAPS_API_KEY — starting on the OpenStreetMap basemap. '
+        + 'Photorealistic 3D Tiles, geocoding and place context stay off until a key is set.'
+      );
     }
-    Cesium.GoogleMaps.defaultApiKey = googleApiKey;
-
-    // Expose API key globally for geocoding in locations.js
-    window.__GOOGLE_MAPS_API_KEY__ = googleApiKey;
 
     // Create the Cesium viewer with minimal chrome
     const viewer = new Cesium.Viewer('cesiumContainer', {
@@ -153,23 +171,30 @@ async function init() {
     viewer.scene.skyAtmosphere.saturationShift = -0.12;
     viewer.scene.skyAtmosphere.brightnessShift = -0.08;
 
-    loaderStatus.textContent = 'Loading Google 3D Tiles...';
     let tileset = null;
-    try {
-      // Load Google Photorealistic 3D Tiles
-      tileset = await Cesium.createGooglePhotorealistic3DTileset({
-        onlyUsingWithGoogleGeocoder: true,
-      });
-      viewer.scene.primitives.add(tileset);
-      // NOTE: Cesium World Terrain intentionally disabled — conflicts with Google 3D Tiles at high zoom.
-      // Google Photorealistic 3D Tiles provide their own terrain/elevation.
-      viewer.scene.globe.show = false;
-    } catch (tileError) {
-      console.warn('[Init] Google 3D Tiles unavailable, falling back to Cesium globe:', tileError);
-      const tileErrorDetail = describeError(tileError);
-      loaderStatus.textContent = `Google 3D Tiles unavailable (${tileErrorDetail}). Continuing in fallback mode...`;
-      // Keep Cesium globe visible as fallback instead of aborting the app.
+    if (!googleApiKey) {
+      // No key, so nothing to request: keep Cesium's own globe visible and let
+      // MapStackController start on the keyless OSM stack.
+      loaderStatus.textContent = 'No Google key — using the OpenStreetMap globe...';
       viewer.scene.globe.show = true;
+    } else {
+      try {
+        loaderStatus.textContent = 'Loading Google 3D Tiles...';
+        // Load Google Photorealistic 3D Tiles
+        tileset = await Cesium.createGooglePhotorealistic3DTileset({
+          onlyUsingWithGoogleGeocoder: true,
+        });
+        viewer.scene.primitives.add(tileset);
+        // NOTE: Cesium World Terrain intentionally disabled — conflicts with Google 3D Tiles at high zoom.
+        // Google Photorealistic 3D Tiles provide their own terrain/elevation.
+        viewer.scene.globe.show = false;
+      } catch (tileError) {
+        console.warn('[Init] Google 3D Tiles unavailable, falling back to Cesium globe:', tileError);
+        const tileErrorDetail = describeError(tileError);
+        loaderStatus.textContent = `Google 3D Tiles unavailable (${tileErrorDetail}). Continuing in fallback mode...`;
+        // Keep Cesium globe visible as fallback instead of aborting the app.
+        viewer.scene.globe.show = true;
+      }
     }
 
     loaderStatus.textContent = 'Initializing systems...';
@@ -264,7 +289,27 @@ async function init() {
         // dataManager is passed explicitly: the globe missions enable bundled
         // keyless layers through it, and reaching for styleManager._dataManager
         // would make a private field part of this feature's contract.
-        initFirstRunExperience({ styleManager, dataManager });
+        const firstRun = initFirstRunExperience({ styleManager, dataManager });
+        // Static hosts have no /api middleware. Say so once, here rather than
+        // per failing layer, and offer the browser-side keys that turn a
+        // forked deployment into a photorealistic one without a rebuild.
+        // It QUEUES behind the first-run card: both are centred dialogs, and
+        // two of them at once is a wall of text over the globe. The card
+        // removes itself on dismiss, so that removal is the cue.
+        const revealStaticNotice = () => {
+          showStaticDeploymentNotice({ hasGoogleKey: Boolean(googleApiKey) });
+        };
+        const firstRunCard = firstRun && document.getElementById('first-run-launcher');
+        if (!firstRunCard) {
+          revealStaticNotice();
+        } else {
+          const watcher = new MutationObserver(() => {
+            if (document.getElementById('first-run-launcher')) return;
+            watcher.disconnect();
+            revealStaticNotice();
+          });
+          watcher.observe(document.body, { childList: true, subtree: true });
+        }
       };
       loadingScreen.addEventListener('transitionend', revealFirstRun, { once: true });
       setTimeout(revealFirstRun, 900);

--- a/src/staticDeployment.js
+++ b/src/staticDeployment.js
@@ -1,0 +1,279 @@
+/**
+ * Static-hosting support (GitHub Pages, Netlify, any plain file server).
+ *
+ * Every live feed in this app is brokered by middleware that lives in
+ * `vite.config.js` and only runs under `vite dev` — the proxies hold the
+ * server-side keys (OpenSky, TomTom, FIRMS, AISStream, OpenAI…) so they never
+ * reach the browser. A built bundle served from a static host has no such
+ * middleware, so `/api/*` simply is not there.
+ *
+ * That is a deployment fact, not a bug, and the app is still worth hosting: the
+ * globe, the visual styles, the camera/scene work, share links, the bundled
+ * datasets (submarine cables, data centres, dams, regions) and the feeds that
+ * are CORS-open direct from the browser (USGS earthquakes, GBFS bikeshare) all
+ * work with no server at all.
+ *
+ * This module makes that split explicit instead of leaving it to look broken:
+ *
+ *  - `installStaticApiStub()` answers `/api/*` with a 503 carrying a plain
+ *    explanation, so each layer's existing error surface shows the reason
+ *    rather than choking on a host's 404 HTML page.
+ *  - `showStaticDeploymentNotice()` explains it once, and lets a visitor paste
+ *    their own client-side keys so a fork works without rebuilding.
+ */
+
+import { appAssetUrl } from './appAssetUrl.js';
+
+/**
+ * True when this bundle was produced by `vite build` without a declared API
+ * backend. Set from `vite.config.js`; see `GEV_STATIC_BUILD` in `.env.example`
+ * for the escape hatch when `dist/` is served behind a real proxy.
+ */
+export const IS_STATIC_BUILD = import.meta.env.GEV_STATIC_BUILD === true;
+
+/** Same-origin path prefix owned by the dev-server proxies. */
+const API_PREFIX = '/api/';
+
+/** Shown by each layer's own status readout when it polls a missing backend. */
+export const NO_BACKEND_MESSAGE =
+  'Live feed needs the local server — run npm run dev';
+
+/** localStorage namespace, matching the app's existing `godsEyeView.` keys. */
+const CREDENTIAL_PREFIX = 'godsEyeView.credentials.';
+
+/** Keys the browser is *supposed* to hold (see SECURITY.md); no others. */
+const CLIENT_CREDENTIALS = Object.freeze({
+  GOOGLE_MAPS_API_KEY: {
+    label: 'Google Maps API key',
+    hint: 'Map Tiles API enabled — unlocks the photorealistic 3D globe',
+  },
+  CESIUM_ION_TOKEN: {
+    label: 'Cesium ion token',
+    hint: 'Optional — adds the Bing aerial basemap stacks',
+  },
+});
+
+/**
+ * Build-time values, read STATICALLY on purpose.
+ *
+ * These are injected by `define` in `vite.config.js`, which is a literal text
+ * substitution of `import.meta.env.NAME`. A computed lookup like
+ * `import.meta.env[name]` is not rewritten and would read undefined in a
+ * build — only `VITE_`-prefixed vars survive dynamic access.
+ */
+const BUILD_CREDENTIALS = Object.freeze({
+  GOOGLE_MAPS_API_KEY: import.meta.env.GOOGLE_MAPS_API_KEY,
+  CESIUM_ION_TOKEN: import.meta.env.CESIUM_ION_TOKEN,
+});
+
+const NOTICE_DISMISSED_KEY = 'godsEyeView.staticNoticeDismissed.v1';
+
+/** @returns {Storage|null} localStorage, or null where it is unavailable. */
+function storage() {
+  try {
+    return globalThis.localStorage ?? null;
+  } catch {
+    // Private mode / blocked storage — the app still runs, keys just don't persist.
+    return null;
+  }
+}
+
+/**
+ * Read a client-side credential, preferring one the visitor supplied here.
+ *
+ * A build-time value (repo secret injected by CI) is the normal path; the
+ * localStorage override exists so someone can point a public deployment at
+ * their own quota without forking and rebuilding.
+ *
+ * @param {keyof typeof CLIENT_CREDENTIALS} name
+ * @returns {string} the credential, or '' when unset.
+ */
+export function readClientCredential(name) {
+  if (!(name in CLIENT_CREDENTIALS)) return '';
+  const stored = storage()?.getItem(CREDENTIAL_PREFIX + name);
+  if (typeof stored === 'string' && stored.trim()) return stored.trim();
+  const built = BUILD_CREDENTIALS[name];
+  return typeof built === 'string' && built.trim() ? built.trim() : '';
+}
+
+/**
+ * Persist (or clear, with an empty value) a visitor-supplied credential.
+ *
+ * @param {keyof typeof CLIENT_CREDENTIALS} name
+ * @param {string} value
+ * @returns {boolean} whether the write landed.
+ */
+export function writeClientCredential(name, value) {
+  if (!(name in CLIENT_CREDENTIALS)) return false;
+  const store = storage();
+  if (!store) return false;
+  try {
+    const trimmed = String(value ?? '').trim();
+    if (trimmed) store.setItem(CREDENTIAL_PREFIX + name, trimmed);
+    else store.removeItem(CREDENTIAL_PREFIX + name);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+let _stubInstalled = false;
+
+/**
+ * Answer same-origin `/api/*` requests locally with an explanatory 503.
+ *
+ * Layers already treat a non-ok response as an upstream outage and surface
+ * `body.error` in their status line, so this reuses that path instead of
+ * touching any layer. Without it, a static host answers those polls with its
+ * own 404 HTML, which reads as a parse error rather than a missing backend.
+ *
+ * @returns {boolean} whether the stub was installed by this call.
+ */
+export function installStaticApiStub() {
+  if (_stubInstalled || !IS_STATIC_BUILD) return false;
+  if (typeof window === 'undefined' || typeof window.fetch !== 'function') return false;
+
+  const nativeFetch = window.fetch.bind(window);
+  window.fetch = function gevStaticFetch(input, init) {
+    let target;
+    try {
+      const raw = typeof input === 'string' ? input : (input?.url ?? '');
+      target = new URL(raw, document.baseURI);
+    } catch {
+      return nativeFetch(input, init);
+    }
+    if (target.origin !== window.location.origin) return nativeFetch(input, init);
+    if (!target.pathname.startsWith(API_PREFIX)) return nativeFetch(input, init);
+
+    return Promise.resolve(new Response(
+      JSON.stringify({ error: NO_BACKEND_MESSAGE, staticBuild: true }),
+      {
+        status: 503,
+        statusText: 'Service Unavailable',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Gev-Static-Build': '1',
+        },
+      },
+    ));
+  };
+  _stubInstalled = true;
+  return true;
+}
+
+/** Feeds that reach their upstream straight from the browser — no proxy needed. */
+const WORKS_WITHOUT_BACKEND = [
+  'the 3D globe, visual styles, camera and scene director',
+  'earthquakes (USGS) and bikeshare (GBFS), fetched straight from source',
+  'the bundled datasets: submarine cables, data centres, dams, regions',
+  'share links and the annotation tools',
+];
+
+/** Feeds brokered by the dev-server proxies, so unavailable on a static host. */
+const NEEDS_BACKEND = [
+  'aircraft and military flights',
+  'satellites, rocket launches, active fires',
+  'street traffic, CCTV, radio, live vessels',
+  'voice control',
+];
+
+function noticeDismissed() {
+  try {
+    return storage()?.getItem(NOTICE_DISMISSED_KEY) === '1';
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Show the one-time static-deployment explainer.
+ *
+ * Deliberately not a blocking modal: the globe behind it is the point, and the
+ * banner is dismissible for good. It is also the only place a visitor can add
+ * their own client-side keys, which is what makes a forked Pages deployment
+ * usable without a rebuild.
+ *
+ * @param {object} [options]
+ * @param {boolean} [options.hasGoogleKey] Whether the photoreal globe came up.
+ * @param {boolean} [options.force] Show even if previously dismissed.
+ * @returns {HTMLElement|null} the banner element, or null when not shown.
+ */
+export function showStaticDeploymentNotice({ hasGoogleKey = false, force = false } = {}) {
+  if (!IS_STATIC_BUILD) return null;
+  if (typeof document === 'undefined') return null;
+  if (!force && noticeDismissed()) return null;
+  if (document.getElementById('static-build-notice')) return null;
+
+  const banner = document.createElement('aside');
+  banner.id = 'static-build-notice';
+  banner.setAttribute('role', 'dialog');
+  banner.setAttribute('aria-label', 'Static deployment notice');
+
+  const list = (items) => items.map((item) => `<li>${item}</li>`).join('');
+  const keyRows = Object.entries(CLIENT_CREDENTIALS).map(([name, meta]) => `
+    <label class="static-build-key">
+      <span class="static-build-key-name">${meta.label}</span>
+      <input type="password" name="${name}" autocomplete="off" spellcheck="false"
+             placeholder="${readClientCredential(name) ? '•••••• stored' : 'paste to enable'}" />
+      <small>${meta.hint}</small>
+    </label>`).join('');
+
+  banner.innerHTML = `
+    <div class="static-build-head">
+      <img class="static-build-logo" src="${appAssetUrl('/logo.svg')}" alt="" />
+      <div>
+        <h2>Running without a local server</h2>
+        <p>This is the static build. Everything below works right now${
+          hasGoogleKey ? '' : ', on the OpenStreetMap globe'
+        } — the live intelligence feeds need the dev server, which brokers their keys.</p>
+      </div>
+      <button type="button" class="static-build-close" aria-label="Dismiss">&times;</button>
+    </div>
+    <div class="static-build-cols">
+      <section>
+        <h3>Works here</h3>
+        <ul>${list(WORKS_WITHOUT_BACKEND)}</ul>
+      </section>
+      <section>
+        <h3>Needs <code>npm run dev</code></h3>
+        <ul>${list(NEEDS_BACKEND)}</ul>
+      </section>
+    </div>
+    <form class="static-build-keys">
+      <p>Optional — use your own browser-side keys on this deployment. They stay
+         in this browser's local storage and are never sent anywhere but the
+         mapping provider.</p>
+      ${keyRows}
+      <div class="static-build-actions">
+        <button type="submit">Save and reload</button>
+        <button type="button" class="static-build-dismiss">Not now</button>
+      </div>
+    </form>
+  `;
+
+  const close = () => {
+    try {
+      storage()?.setItem(NOTICE_DISMISSED_KEY, '1');
+    } catch {
+      // Dismissal just won't persist; closing still works.
+    }
+    banner.remove();
+  };
+
+  banner.querySelector('.static-build-close')?.addEventListener('click', close);
+  banner.querySelector('.static-build-dismiss')?.addEventListener('click', close);
+  banner.querySelector('form')?.addEventListener('submit', (event) => {
+    event.preventDefault();
+    let changed = false;
+    for (const name of Object.keys(CLIENT_CREDENTIALS)) {
+      const field = banner.querySelector(`input[name="${name}"]`);
+      const value = field?.value?.trim();
+      if (value) changed = writeClientCredential(name, value) || changed;
+    }
+    close();
+    if (changed) window.location.reload();
+  });
+
+  document.body.appendChild(banner);
+  return banner;
+}

--- a/src/voice/gevRealtime.js
+++ b/src/voice/gevRealtime.js
@@ -1,3 +1,4 @@
+import { appAssetUrl } from '../appAssetUrl.js';
 import { createGevActionRunner, readLayerLifecycleSummary } from './gevActions.js';
 import {
   DEFAULT_VOICE_TIER,
@@ -2560,7 +2561,7 @@ function createVoiceControl({ reset = false } = {}) {
         </div>
       </div>
       <button id="gev-voice-button" type="button" aria-label="Voice control — hold Space to speak; click to toggle voice" aria-describedby="gev-voice-help">
-        <span class="gev-mic-orbit"><img src="/mic.svg" alt="" /></span>
+        <span class="gev-mic-orbit"><img src="${appAssetUrl('/mic.svg')}" alt="" /></span>
         <span class="gev-mic-label">ON/OFF</span>
       </button>
       <div class="gev-voice-visualizer" aria-hidden="true">

--- a/style.css
+++ b/style.css
@@ -425,9 +425,14 @@ body.cockpit-mode #cockpit-cloud-effects.active {
 /* ── Title Bar ────────────────────────────────── */
 #title-bar {
   position: fixed;
-  top: 32px;
-  left: 36px;
+  /* Fluid inset: the title is one of three fixed items sharing the top row
+     (title / #top-center-actions / #style-indicator). Pulling it toward the
+     corner on narrow viewports is what keeps the centered action buttons
+     clear — see the responsive block below. */
+  top: clamp(14px, 2.4vw, 32px);
+  left: clamp(14px, 2.5vw, 36px);
   z-index: 100;
+  max-width: calc(100vw - clamp(28px, 5vw, 72px));
   pointer-events: none;
   user-select: none;
 }
@@ -436,8 +441,8 @@ body.cockpit-mode #cockpit-cloud-effects.active {
   position: absolute;
   top: -20px;
   left: -20px;
-  width: 200px;
-  height: 80px;
+  width: clamp(120px, 26vw, 200px);
+  height: clamp(52px, 10vw, 80px);
   background: radial-gradient(ellipse, var(--accent-dim) 0%, transparent 70%);
   filter: blur(20px);
   opacity: 0.6;
@@ -446,11 +451,16 @@ body.cockpit-mode #cockpit-cloud-effects.active {
 #title-bar h1 {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: clamp(7px, 1.1vw, 12px);
   font-family: var(--font-mono);
-  font-size: 26px;
+  /* Fluid type. The 26px/8px pair is the full-size design (reached at ~1090px
+     and above, which is the framing used in the demo); below that both the
+     glyph size and the tracking scale together so the wordmark keeps its
+     proportions instead of running off the viewport. */
+  font-size: clamp(12px, 2.4vw, 26px);
   font-weight: 600;
-  letter-spacing: 8px;
+  letter-spacing: clamp(1.5px, 0.74vw, 8px);
+  white-space: nowrap;
   color: var(--text-primary);
   text-shadow: 0 0 30px var(--accent-glow);
   position: relative;
@@ -459,7 +469,8 @@ body.cockpit-mode #cockpit-cloud-effects.active {
 #title-bar .title-logo {
   position: relative;
   display: block;
-  width: 52px;
+  width: clamp(24px, 4.6vw, 52px);
+  flex: none;
   height: auto;
   filter: drop-shadow(0 0 12px rgba(0, 246, 255, 0.5));
 }
@@ -537,19 +548,24 @@ body.cockpit-mode #cockpit-cloud-effects.active {
 
 #title-bar .subtitle {
   font-family: var(--font-mono);
-  font-size: 11px;
-  letter-spacing: 5px;
+  font-size: clamp(8px, 1vw, 11px);
+  letter-spacing: clamp(1.5px, 0.46vw, 5px);
   color: var(--text-dim);
-  margin-top: 8px;
+  margin-top: clamp(4px, 0.7vw, 8px);
   text-transform: uppercase;
+  white-space: nowrap;
 }
+
+/* Narrow-viewport layout for the title bar lives with #top-center-actions
+   further down, so the cascade order can override that rule too. */
 
 /* ── Style Indicator ──────────────────────────── */
 #style-indicator {
   position: fixed;
-  top: 32px;
-  right: 36px;
+  top: clamp(14px, 2.4vw, 32px);
+  right: clamp(14px, 2.5vw, 36px);
   z-index: 100;
+  max-width: calc(50vw - clamp(20px, 4vw, 44px));
   pointer-events: none;
   user-select: none;
   text-align: right;
@@ -558,8 +574,9 @@ body.cockpit-mode #cockpit-cloud-effects.active {
 #style-indicator .indicator-label {
   display: block;
   font-family: var(--font-mono);
-  font-size: 10px;
-  letter-spacing: 3px;
+  font-size: clamp(8px, 0.92vw, 10px);
+  letter-spacing: clamp(1.5px, 0.28vw, 3px);
+  white-space: nowrap;
   color: var(--text-dim);
   text-transform: uppercase;
 }
@@ -567,11 +584,12 @@ body.cockpit-mode #cockpit-cloud-effects.active {
 #style-indicator .indicator-value {
   display: block;
   font-family: var(--font-mono);
-  font-size: 16px;
+  font-size: clamp(10px, 1.47vw, 16px);
   font-weight: 500;
-  letter-spacing: 5px;
+  letter-spacing: clamp(1.5px, 0.46vw, 5px);
   color: var(--accent);
   margin-top: 4px;
+  white-space: nowrap;
   text-shadow: 0 0 20px var(--accent-glow);
   transition: var(--transition-smooth);
 }
@@ -1919,6 +1937,52 @@ body.ui-clean-view #scene-runtime.active {
 #top-center-actions .material-symbols-outlined {
   font-size: 18px;
 }
+
+/* ── Top-row chrome on narrow viewports ───────────
+   Three fixed items share the top row: #title-bar (left), #top-center-actions
+   (centred) and #style-indicator (right). Fluid type above keeps each one from
+   overflowing, but under ~640px the centre slot is too narrow to sit between
+   the other two — the wordmark ran straight through the buttons and off the
+   right edge. Below that width the actions un-centre to the right rail and the
+   style readout drops to the line beneath them, so the layout keeps the
+   designed hierarchy (brand left, state right) without any overlap. */
+@media (max-width: 640px) {
+  /* One source for the shared top inset, so the action row and the readout
+     stacked beneath it cannot drift apart from the title they align with. */
+  #top-center-actions,
+  #style-indicator {
+    --top-row-inset: clamp(14px, 2.4vw, 32px);
+    --top-row-height: 32px;
+  }
+
+  #top-center-actions {
+    top: var(--top-row-inset);
+    left: auto;
+    right: clamp(14px, 2.5vw, 36px);
+    gap: 8px;
+    transform: none;
+  }
+
+  #top-center-actions button {
+    width: var(--top-row-height);
+    height: var(--top-row-height);
+  }
+
+  #style-indicator {
+    /* Clear the action row that now occupies the top-right corner. */
+    top: calc(var(--top-row-inset) + var(--top-row-height) + 10px);
+    max-width: calc(100vw - clamp(28px, 5vw, 72px));
+  }
+}
+
+@media (max-width: 400px) {
+  #title-bar .subtitle {
+    /* Decorative tagline only — it is the first thing to go when the
+       wordmark itself needs the room. */
+    display: none;
+  }
+}
+
 
 #global-loading-status {
   position: fixed;
@@ -4237,7 +4301,11 @@ body.cockpit-mode #intel-hud .hud-right-edge { right: 22px; }
 
 .hud-summary-wrap {
   margin-top: 6px;
-  max-width: 420px;
+  /* The summary is the widest thing in the top-left corner, so it sets the
+     whole readout's width. A flat 420px overran a phone viewport by ~70px —
+     the corner is inset and carries a bracket glyph, so the usable width is
+     roughly `100vw - 4rem`. The cap still wins at every desktop size. */
+  max-width: min(420px, calc(100vw - 4rem));
 }
 
 .hud-summary-label {
@@ -4370,7 +4438,7 @@ body.cockpit-mode #intel-hud .hud-right-edge { right: 22px; }
 }
 
 #intel-hud[data-variant='minimal'] .hud-summary-wrap {
-  max-width: 280px;
+  max-width: min(280px, calc(100vw - 4rem));
 }
 
 /* ── Data Layer Toggle Panel ─────────────────── */
@@ -6782,23 +6850,12 @@ body.scene-playback-mode :is(#clear-selected-layers, #reset-globe-view) {
     max-width: none;
   }
 
-  #title-bar {
-    top: 20px;
-    left: 20px;
-  }
-
-  #title-bar h1 {
-    font-size: 16px;
-    letter-spacing: 4px;
-  }
-
-  #title-bar h1 {
-    gap: 8px;
-  }
-
-  #title-bar .title-logo {
-    width: 36px;
-  }
+  /* The title bar's own sizes used to step down here — a single hard jump at
+     720px, with nothing between it and the full 26px design, so the wordmark
+     collided with the centred action buttons through the whole 721-1090px
+     range and still overran the buttons under ~500px. Its type, logo, gap and
+     inset are all fluid now (see the #title-bar rules), which covers this
+     width continuously; overriding them again here would freeze that scale. */
 
   #location-bar {
     left: 16px;
@@ -9160,4 +9217,197 @@ body.scene-playback-mode #first-run-launcher {
   .first-run-arrow { transition: none; }
   /* Scrolling a tile into view must not animate either. */
   .first-run-choices { scroll-behavior: auto; }
+}
+
+/* ── Static deployment notice ─────────────────────
+   Shown once on a build with no /api middleware behind it (GitHub Pages and
+   friends). It explains which half of the app is live and takes the two
+   browser-side keys, so a forked deployment can reach the photorealistic globe
+   without a rebuild. Same glass idiom as the panels; z-index sits above the
+   panel band (100-139) and the voice pill (150), below the toast (200). */
+#static-build-notice {
+  position: fixed;
+  z-index: 160;
+  bottom: max(1.25rem, env(safe-area-inset-bottom));
+  left: 50%;
+  width: min(46rem, calc(100vw - 1.5rem));
+  max-height: min(30rem, calc(100dvh - 6rem));
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding: clamp(0.9rem, 2vw, 1.4rem);
+  transform: translateX(-50%);
+  color: var(--text-primary);
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--panel-radius);
+  box-shadow:
+    0 18px 48px rgba(0, 0, 0, 0.6),
+    0 0 24px rgba(0, 212, 255, 0.08);
+  backdrop-filter: blur(24px) saturate(1.4);
+  -webkit-backdrop-filter: blur(24px) saturate(1.4);
+  font-family: var(--font-sans);
+  font-size: 0.82rem;
+  line-height: 1.5;
+}
+
+#static-build-notice .static-build-head {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+#static-build-notice .static-build-logo {
+  width: 2.25rem;
+  height: auto;
+  flex: none;
+  filter: drop-shadow(0 0 10px rgba(0, 246, 255, 0.45));
+}
+
+#static-build-notice h2 {
+  margin: 0 0 0.25rem;
+  font-family: var(--font-mono);
+  font-size: 0.92rem;
+  font-weight: 600;
+  letter-spacing: 1.5px;
+  text-transform: uppercase;
+}
+
+#static-build-notice p {
+  margin: 0;
+  color: var(--text-secondary);
+}
+
+#static-build-notice .static-build-close {
+  margin-left: auto;
+  padding: 0 0.35rem;
+  font-size: 1.15rem;
+  line-height: 1;
+  color: var(--text-secondary);
+  background: none;
+  border: 0;
+  cursor: pointer;
+}
+
+#static-build-notice .static-build-close:hover,
+#static-build-notice .static-build-close:focus-visible {
+  color: var(--text-primary);
+}
+
+#static-build-notice .static-build-cols {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.75rem 1.25rem;
+  margin-top: 0.9rem;
+}
+
+#static-build-notice h3 {
+  margin: 0 0 0.3rem;
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  font-weight: 500;
+  letter-spacing: 2px;
+  color: var(--accent);
+  text-transform: uppercase;
+}
+
+#static-build-notice ul {
+  margin: 0;
+  padding-left: 1.05rem;
+  color: var(--text-secondary);
+}
+
+#static-build-notice code {
+  font-family: var(--font-mono);
+  font-size: 0.92em;
+  color: var(--text-primary);
+}
+
+#static-build-notice .static-build-keys {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.6rem 1.25rem;
+  margin-top: 1rem;
+  padding-top: 0.9rem;
+  border-top: 1px solid var(--glass-border);
+}
+
+#static-build-notice .static-build-keys > p,
+#static-build-notice .static-build-actions {
+  grid-column: 1 / -1;
+}
+
+#static-build-notice .static-build-key {
+  display: block;
+}
+
+#static-build-notice .static-build-key-name {
+  display: block;
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  letter-spacing: 1.5px;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+}
+
+#static-build-notice input {
+  width: 100%;
+  margin-top: 0.3rem;
+  padding: 0.4rem 0.55rem;
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  color: var(--text-primary);
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--btn-radius);
+  outline: none;
+}
+
+#static-build-notice input:focus-visible {
+  border-color: var(--accent);
+}
+
+#static-build-notice small {
+  display: block;
+  margin-top: 0.25rem;
+  font-size: 0.68rem;
+  color: var(--text-dim);
+}
+
+#static-build-notice .static-build-actions {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 0.25rem;
+}
+
+#static-build-notice .static-build-actions button {
+  padding: 0.45rem 0.9rem;
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  letter-spacing: 1.5px;
+  color: var(--text-primary);
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--btn-radius);
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+#static-build-notice .static-build-actions button[type='submit'] {
+  color: var(--accent);
+  border-color: var(--accent-glow);
+}
+
+#static-build-notice .static-build-actions button:hover,
+#static-build-notice .static-build-actions button:focus-visible {
+  border-color: var(--glass-border-hover);
+  background: rgba(255, 255, 255, 0.09);
+}
+
+/* Single column once two columns would leave each side too narrow to read. */
+@media (max-width: 620px) {
+  #static-build-notice .static-build-cols,
+  #static-build-notice .static-build-keys {
+    grid-template-columns: minmax(0, 1fr);
+  }
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -7330,7 +7330,7 @@ function normalizeAisTimestamp(value) {
  * plugins, configures the dev server host/port, and exposes selected
  * API keys to the client as import.meta.env defines.
  */
-export default defineConfig(({ mode }) => {
+export default defineConfig(({ mode, command }) => {
   // Load only this checkout's dotenv files. Shell/Keychain values still win,
   // and no sibling workspace is consulted implicitly.
   const loaded = loadEnv(mode, __dirname, '');
@@ -7338,7 +7338,16 @@ export default defineConfig(({ mode }) => {
     if (process.env[key] === undefined) process.env[key] = val;
   }
   const env = { ...process.env };
+  // Relative base for builds so one artifact is valid at any URL prefix. A
+  // GitHub Pages *project* site is served from `/<repo>/`, and an absolute
+  // `/assets/...` would resolve to the domain root and 404 there. Relative
+  // URLs also keep `dist/` openable from a plain static file server, and they
+  // sidestep vite-plugin-cesium copying its runtime to `dist/<base>/cesium`
+  // when a non-root absolute base is set. The dev server always serves from
+  // the root, so it keeps '/'.
+  const base = command === 'build' ? './' : '/';
   return {
+    base,
     plugins: [
       cesium(),
       openSkyProxy(),
@@ -7370,9 +7379,20 @@ export default defineConfig(({ mode }) => {
         : ['localhost', '127.0.0.1', '.local'],
     },
     // Expose selected API keys to the browser via import.meta.env.*
+    // NOTE: `define` is a literal text substitution, so these must always be
+    // read as `import.meta.env.NAME` in source — a computed lookup is not
+    // rewritten (only VITE_-prefixed vars survive dynamic access).
     define: {
       'import.meta.env.GOOGLE_MAPS_API_KEY': JSON.stringify(env.GOOGLE_MAPS_API_KEY),
       'import.meta.env.CESIUM_ION_TOKEN': JSON.stringify(env.CESIUM_ION_TOKEN),
+      // A build has no /api middleware: every proxy above is `configureServer`,
+      // so it runs under `vite dev` only — `vite preview` has none either.
+      // The app uses this to explain the gap rather than let each layer fail
+      // opaquely. Set GEV_STATIC_BUILD=0 when serving `dist/` behind a real
+      // backend that provides the same /api surface.
+      'import.meta.env.GEV_STATIC_BUILD': JSON.stringify(
+        command === 'build' && !/^(0|false|no)$/i.test(String(env.GEV_STATIC_BUILD ?? '')),
+      ),
     },
     build: {
       // The Cesium engine bundle is inherently large; raise the warning ceiling


### PR DESCRIPTION
The fork could not be published as a static site and the wordmark overran narrow viewports. Both are fixed here.

Responsive top row

  #title-bar and #style-indicator were the only fixed top-row chrome with no
  fluid sizing: 26px type at 8px tracking, a 52px logo and hard 32/36px insets.
  At 1440px that is 395px wide, so from ~721px down the wordmark ran straight
  through the centred action buttons and off the right edge. A single hard
  step-down existed at 720px, which left the 721-1090px range uncovered and
  still collided under ~500px.

  Type, tracking, logo, gap and insets are now clamp()-scaled, so the full-size
  design is reached at ~1090px and degrades continuously below it — 1440px
  renders byte-identical to before. Under 640px the action row un-centres to
  the right rail and the style readout stacks beneath it, which is the only
  way three items fit one row on a phone. The now-redundant 720px overrides
  are removed; leaving them would freeze the fluid scale.

  .hud-summary-wrap had the same problem: a flat 420px cap overran a 390px
  viewport by ~70px, and since it is the widest child it dragged the whole
  intel readout with it. Capped against the viewport too.

  Verified 320-1440px: no horizontal overflow and no overlapping chrome.

Static hosting

  Every live feed is brokered by configureServer middleware in vite.config.js,
  so it runs under `vite dev` only. A static host cannot run it, and /api/*
  does not exist there. That is a property of static hosting, not a bug — and
  the globe, styles, share links, bundled datasets and the CORS-open feeds
  (USGS, GBFS) never needed a backend at all.

  - Builds use a relative base, so one artifact is valid at any URL prefix. This also avoids vite-plugin-cesium copying its runtime to dist/<base>/ when a non-root absolute base is set. Dev keeps '/'.
  - Runtime-assembled asset paths (aircraft GLBs, logo, mic) resolve against document.baseURI via a new appAssetUrl helper. The source strings stay put since several are identity keys pinned by tests.
  - A missing GOOGLE_MAPS_API_KEY no longer aborts init. MapStackController already fell back to the keyless OSM stack; the app now boots on it and explains itself instead of showing an error on a black screen.
  - Static builds answer their own /api calls with an explanatory 503, so each layer's existing error surface reads "needs the local server" rather than choking on the host's 404 HTML. GEV_STATIC_BUILD=0 opts out.
  - A one-time notice states which half of the app is live and accepts the two browser-side keys into localStorage, so a keyless deployment is still useful — visitors can point it at their own quota without a rebuild.

Adds the Pages workflow (keys optional, via repo secrets), docs/GITHUB-PAGES.md and README/.env.example pointers. Full suite passes (2587).


Claude-Session: https://claude.ai/code/session_01FhXFJjdiwFFMcdou5QbeAQ