### PR TITLE
Add Docker support and optional self-hosted LiveKit voice

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+.git
+docs/media
+.gev-cache
+*.wav

--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,10 @@ GOOGLE_MAPS_API_KEY=your_google_maps_api_key_here
 # CLIENT-EXPOSED — use a public assets:read token with URL restrictions.
 CESIUM_ION_TOKEN=
 
+# Optional: voice backend. Default is OpenAI Realtime. Set to livekit for the
+# self-hosted LiveKit stack in docker-compose.livekit.yml.
+VITE_VOICE_BACKEND=openai
+
 # Optional: OpenAI Realtime voice control. Do not prefix with VITE_.
 OPENAI_API_KEY=
 OPENAI_REALTIME_MODEL=gpt-realtime-2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+# God's Eye View — container image
+# Single service: `vite` dev server serves the SPA plus all 20 API proxy
+# middlewares from vite.config.js. NOTE: run the DEV server, not `vite
+# preview` — 18 of the 20 proxies only register via configureServer(),
+# so preview would silently drop most data layers.
+# Only 2 env vars are baked in at build time (client-exposed by design):
+# GOOGLE_MAPS_API_KEY, CESIUM_ION_TOKEN. Everything else is read at runtime.
+
+FROM node:24-slim
+
+# QA scripts use puppeteer; the API proxies only need `ws` at runtime.
+# Skip the ~170 MB Chrome download to keep the image lean.
+ENV PUPPETEER_SKIP_DOWNLOAD=true
+
+WORKDIR /app
+
+# Lockfile first for layer caching
+COPY package.json package-lock.json ./
+RUN npm ci
+
+# App source + config
+COPY . .
+
+# Disk cache dir for Overpass / military-installation proxies (mount a volume
+# to persist across restarts)
+VOLUME ["/app/.gev-cache"]
+
+ENV HOST=0.0.0.0 \
+    PORT=4173
+
+EXPOSE 4173
+
+# Dev server (see header comment) — HOST=0.0.0.0 is read by vite.config.js
+CMD ["npm", "run", "dev"]

--- a/README.md
+++ b/README.md
@@ -79,6 +79,25 @@ The dev server binds to **localhost** — your keys stay on your machine. Sharin
 
 ---
 
+## 🐳 Docker
+
+Prefer a container over a Node install? It's one service — the app and all its API proxies are a single Node process, so there's nothing else to orchestrate:
+
+```bash
+cp .env.example .env   # set GOOGLE_MAPS_API_KEY (plus any others you want)
+docker compose up -d --build
+```
+
+Open **`http://localhost:4173`**.
+
+- **Runs the dev server on purpose.** 18 of the 20 API proxy middlewares register via `configureServer()` only, so `vite preview` would silently serve an SPA with most data layers dead. `npm run dev` in the container is the supported mode.
+- The Overpass / military-installations disk cache (7–30 day TTLs) lives in the `gev-cache` volume and survives restarts.
+- `GOOGLE_MAPS_API_KEY` and `CESIUM_ION_TOKEN` are injected into the client bundle at **build** time — rebuild after changing either: `docker compose build --no-cache && docker compose up -d`. Every other key is read at runtime, so a plain restart picks it up.
+- Image is ~830 MB (Node 24 + the full dependency tree; the puppeteer Chrome download is skipped at build time).
+- The container binds `0.0.0.0` internally and publishes 4173 on the host — same key-brokering trust model as `HOST=0.0.0.0` in [Keys & Costs](#-api-keys). Don't expose it beyond a network you trust.
+
+---
+
 ## 🕐 The First Five Minutes
 
 No account, no signup. The first-run card will offer to stage a mission for you — or run this gauntlet yourself. Somewhere in these five minutes it stops feeling like a demo:

--- a/README.md
+++ b/README.md
@@ -94,6 +94,12 @@ Open **`http://localhost:4173`**.
 - The Overpass / military-installations disk cache (7–30 day TTLs) lives in the `gev-cache` volume and survives restarts.
 - `GOOGLE_MAPS_API_KEY` and `CESIUM_ION_TOKEN` are injected into the client bundle at **build** time — rebuild after changing either: `docker compose build --no-cache && docker compose up -d`. Every other key is read at runtime, so a plain restart picks it up.
 - Image is ~830 MB (Node 24 + the full dependency tree; the puppeteer Chrome download is skipped at build time).
+- **Self-hosted voice alternative:** add the LiveKit overlay to replace OpenAI Realtime with LiveKit + local OpenAI-compatible STT/LLM/TTS services:
+  ```bash
+  npm run livekit:tools
+  docker compose -f docker-compose.yml -f docker-compose.livekit.yml up -d --build
+  ```
+  See [`livekit-voice/README.md`](livekit-voice/README.md) for model choices, GPU notes, and the browser tool bridge.
 - The container binds `0.0.0.0` internally and publishes 4173 on the host — same key-brokering trust model as `HOST=0.0.0.0` in [Keys & Costs](#-api-keys). Don't expose it beyond a network you trust.
 
 ---

--- a/docker-compose.livekit.yml
+++ b/docker-compose.livekit.yml
@@ -1,0 +1,68 @@
+name: gods-eye-view-livekit
+
+services:
+  gods-eye-view:
+    environment:
+      VITE_VOICE_BACKEND: livekit
+      LIVEKIT_URL: ws://livekit:7880
+      LIVEKIT_PUBLIC_URL: ws://localhost:7880
+      LIVEKIT_API_KEY: ${LIVEKIT_API_KEY:-devkey}
+      LIVEKIT_API_SECRET: ${LIVEKIT_API_SECRET:-secret}
+      GEV_LIVEKIT_ROOM_PREFIX: ${GEV_LIVEKIT_ROOM_PREFIX:-gev-voice}
+    depends_on:
+      livekit:
+        condition: service_started
+
+  livekit:
+    image: livekit/livekit-server:latest
+    command: --config /etc/livekit.yaml --dev
+    ports:
+      - "7880:7880"
+      - "7881:7881"
+      - "50000-50100:50000-50100/udp"
+    volumes:
+      - ./livekit-voice/livekit.yaml:/etc/livekit.yaml:ro
+
+  livekit-agent:
+    build:
+      context: .
+      dockerfile: livekit-voice/Dockerfile
+    env_file:
+      - ./livekit-voice/.env.example
+    environment:
+      LIVEKIT_URL: ws://livekit:7880
+    depends_on:
+      livekit:
+        condition: service_started
+      ollama:
+        condition: service_started
+      whisper:
+        condition: service_started
+      tts:
+        condition: service_started
+
+  ollama:
+    image: ollama/ollama:latest
+    volumes:
+      - ollama:/root/.ollama
+    ports:
+      - "11434:11434"
+
+  whisper:
+    image: onerahmet/openai-whisper-asr-webservice:latest
+    environment:
+      ASR_MODEL: ${GEV_LIVEKIT_STT_MODEL:-small}
+      ASR_ENGINE: faster_whisper
+    ports:
+      - "9000:9000"
+
+  tts:
+    image: ghcr.io/matatonic/openedai-speech:latest
+    ports:
+      - "8000:8000"
+    volumes:
+      - openedai-speech:/app/voices
+
+volumes:
+  ollama:
+  openedai-speech:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+services:
+  gods-eye-view:
+    build: .
+    image: gods-eye-view:latest
+    container_name: gods-eye-view
+    ports:
+      - "4173:4173"
+    env_file:
+      # Copy .env.example to .env and fill in keys.
+      # Keys stay server-side except GOOGLE_MAPS_API_KEY / CESIUM_ION_TOKEN,
+      # which are injected into the client bundle at BUILD time — rebuild the
+      # image after changing those two.
+      - .env
+    environment:
+      # Bind inside the container; compose publishes 4173 on the host.
+      HOST: 0.0.0.0
+      PORT: "4173"
+    volumes:
+      # Persists the Overpass / military-installation disk cache (7-30 day TTLs)
+      - gev-cache:/app/.gev-cache
+    restart: unless-stopped
+
+volumes:
+  gev-cache:

--- a/livekit-voice/.env.example
+++ b/livekit-voice/.env.example
@@ -1,0 +1,25 @@
+# Shared with the app's /api/livekit/token endpoint and the worker.
+LIVEKIT_URL=ws://livekit:7880
+LIVEKIT_PUBLIC_URL=ws://localhost:7880
+LIVEKIT_API_KEY=devkey
+LIVEKIT_API_SECRET=secret
+GEV_LIVEKIT_ROOM_PREFIX=gev-voice
+
+# Local OpenAI-compatible LLM endpoint. For Ollama, run: ollama pull qwen3:8b
+GEV_LIVEKIT_LLM_PROVIDER=ollama
+GEV_LIVEKIT_LLM_BASE_URL=http://ollama:11434/v1
+GEV_LIVEKIT_LLM_MODEL=qwen3:8b
+GEV_LIVEKIT_LLM_API_KEY=ollama
+
+# Local OpenAI-compatible Whisper endpoint.
+GEV_LIVEKIT_STT_BASE_URL=http://whisper:9000/v1
+GEV_LIVEKIT_STT_MODEL=small
+GEV_LIVEKIT_STT_API_KEY=local
+
+# Local OpenAI-compatible TTS endpoint backed by Piper voices.
+GEV_LIVEKIT_TTS_BASE_URL=http://tts:8000/v1
+GEV_LIVEKIT_TTS_MODEL=tts-1
+GEV_LIVEKIT_TTS_VOICE=alloy
+GEV_LIVEKIT_TTS_API_KEY=local
+
+GEV_LIVEKIT_TOOL_TIMEOUT_S=20

--- a/livekit-voice/.gitignore
+++ b/livekit-voice/.gitignore
@@ -1,0 +1,4 @@
+.venv/
+__pycache__/
+.pytest_cache/
+.env

--- a/livekit-voice/Dockerfile
+++ b/livekit-voice/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+
+WORKDIR /app
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ffmpeg ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY livekit-voice/requirements.txt /app/requirements.txt
+RUN pip install --no-cache-dir -r /app/requirements.txt
+
+COPY livekit-voice/livekit_voice /app/livekit_voice
+COPY livekit-voice/tools.json /app/tools.json
+COPY livekit-voice/system-prompt.txt /app/system-prompt.txt
+
+CMD ["python", "-m", "livekit_voice.agent", "start"]

--- a/livekit-voice/README.md
+++ b/livekit-voice/README.md
@@ -1,0 +1,92 @@
+# Self-hosted LiveKit voice backend
+
+This is an optional replacement for the OpenAI Realtime voice path. The browser still runs all God's Eye View map tools locally; the LiveKit agent only handles voice, LLM reasoning, and tool-call orchestration.
+
+## Architecture
+
+```text
+browser mic/audio
+  ↕ LiveKit WebRTC
+livekit-server
+  ↕ LiveKit Agents worker
+Whisper-compatible STT → OpenAI-compatible LLM → OpenAI-compatible TTS
+  ↕ reliable LiveKit data packets on topic gev.tools
+browser tool runner (src/voice/gevActions.js)
+```
+
+The tool schemas are exported from the existing `GEV_REALTIME_TOOLS` literal in `vite.config.js`:
+
+```bash
+npm run livekit:tools
+```
+
+That writes `livekit-voice/tools.json`, which the Python worker loads at startup.
+
+## Quick start
+
+```bash
+cp .env.example .env
+cp livekit-voice/.env.example livekit-voice/.env   # optional; edit for your model endpoints
+npm run livekit:tools
+
+docker compose -f docker-compose.yml -f docker-compose.livekit.yml up -d --build
+```
+
+Open `http://localhost:4173`, then use the mic button. The overlay sets `VITE_VOICE_BACKEND=livekit` for the app container.
+
+## Models and hardware
+
+Default env targets a 12 GB GPU-friendly local stack:
+
+- LLM: Ollama OpenAI-compatible API, `qwen3:8b`
+- STT: `onerahmet/openai-whisper-asr-webservice`, `small`, faster-whisper
+- TTS: `ghcr.io/matatonic/openedai-speech`, OpenAI-compatible TTS backed by local voices
+
+Pull the Ollama model once:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.livekit.yml exec ollama ollama pull qwen3:8b
+```
+
+For a vLLM server instead of Ollama, set:
+
+```bash
+GEV_LIVEKIT_LLM_PROVIDER=vllm
+GEV_LIVEKIT_LLM_BASE_URL=http://vllm:8000/v1
+GEV_LIVEKIT_LLM_MODEL=Qwen/Qwen3-8B
+GEV_LIVEKIT_LLM_API_KEY=local
+```
+
+The worker uses OpenAI-compatible APIs for LLM/STT/TTS, so you can replace each service independently.
+
+## Browser tool bridge
+
+The Python agent publishes tool calls over LiveKit data packets:
+
+```json
+{"type":"gev.tool_call","call_id":"...","name":"fly_to_location","arguments":{"query":"Tokyo"}}
+```
+
+The browser runs the existing `runner(name, args, { signal, isCurrent })` contract and returns:
+
+```json
+{"type":"gev.tool_result","call_id":"...","result":{"ok":true}}
+```
+
+No map credentials or globe state leave the browser through the Python worker except explicit tool arguments/results.
+
+## Latency expectations
+
+On a 12 GB RTX 3060, expect conversational turns to be near sub-second only when the model is already warm and the tool path is simple. Globe actions often take longer because tool execution, map loading, and the follow-up narration are real work.
+
+Tune:
+
+- `GEV_LIVEKIT_STT_MODEL=tiny|base|small` for STT latency/accuracy.
+- `GEV_LIVEKIT_LLM_MODEL=qwen3:4b|qwen3:8b` for LLM latency/quality.
+- LiveKit agent endpointing is set to 0.25–0.8s in `livekit_voice/agent.py`.
+
+## Security notes
+
+The demo config uses `devkey` / `secret`. Change `LIVEKIT_API_KEY` and `LIVEKIT_API_SECRET` before exposing beyond localhost or a trusted LAN.
+
+The app container is still a key-brokering server for Google Maps, Cesium, OpenSky, and other APIs. Do not publish it directly to the internet without authentication/rate limiting.

--- a/livekit-voice/livekit.yaml
+++ b/livekit-voice/livekit.yaml
@@ -1,0 +1,11 @@
+port: 7880
+bind_addresses:
+  - "0.0.0.0"
+rtc:
+  tcp_port: 7881
+  port_range_start: 50000
+  port_range_end: 50100
+keys:
+  devkey: secret
+logging:
+  level: info

--- a/livekit-voice/livekit_voice/agent.py
+++ b/livekit-voice/livekit_voice/agent.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+from livekit import agents, rtc
+from livekit.agents import Agent, AgentSession, JobContext, WorkerOptions, cli, function_tool
+from livekit.plugins import openai, silero
+
+from livekit_voice.config import VoiceConfig
+from livekit_voice.tool_bridge import BrowserToolBridge
+
+log = logging.getLogger('gev.livekit_voice')
+
+
+def load_tools(path: str) -> list[dict[str, Any]]:
+    with Path(path).open('r', encoding='utf-8') as fh:
+        tools = json.load(fh)
+    if not isinstance(tools, list):
+        raise ValueError(f'{path} must contain a JSON array')
+    return tools
+
+
+def load_instructions(path: str) -> str:
+    p = Path(path)
+    if p.exists():
+        return p.read_text(encoding='utf-8').strip()
+    return (
+        "You are the God's Eye View voice copilot. Keep responses short. "
+        "When a request changes the globe, call the matching tool first and only "
+        "confirm after the browser returns a result. Never claim an action worked "
+        "unless the tool result has ok=true."
+    )
+
+
+def build_browser_tools(bridge: BrowserToolBridge, tools: list[dict[str, Any]]):
+    livekit_tools = []
+    for schema in tools:
+        name = schema.get('name')
+        if not name:
+            continue
+
+        async def _browser_tool(_tool_name=name, **kwargs):
+            return await bridge.call_tool(_tool_name, kwargs)
+
+        livekit_tools.append(
+            function_tool(
+                _browser_tool,
+                name=name,
+                description=schema.get('description') or f'Run browser tool {name}',
+                raw_schema=schema,
+            )
+        )
+    return livekit_tools
+
+
+def build_llm(cfg: VoiceConfig):
+    if cfg.llm_provider == 'mock':
+        return None
+    return openai.LLM(
+        model=cfg.llm_model,
+        api_key=cfg.llm_api_key,
+        base_url=cfg.llm_base_url,
+        parallel_tool_calls=True,
+    )
+
+
+def build_stt(cfg: VoiceConfig):
+    return openai.STT(
+        model=cfg.stt_model,
+        api_key=cfg.stt_api_key,
+        base_url=cfg.stt_base_url,
+    )
+
+
+def build_tts(cfg: VoiceConfig):
+    if cfg.tts_provider == 'mock':
+        return None
+    return openai.TTS(
+        model=cfg.tts_model,
+        voice=cfg.tts_voice,
+        api_key=cfg.tts_api_key,
+        base_url=cfg.tts_base_url,
+    )
+
+
+async def entrypoint(ctx: JobContext):
+    cfg = VoiceConfig.from_env()
+    await ctx.connect(auto_subscribe=agents.AutoSubscribe.SUBSCRIBE_ALL)
+
+    def send_json(payload: dict[str, Any]):
+        data = json.dumps(payload, separators=(',', ':'))
+        ctx.room.local_participant.publish_data(data, reliable=True, topic='gev.tools')
+
+    bridge = BrowserToolBridge(send_json=send_json, timeout_s=cfg.tool_timeout_s)
+
+    @ctx.room.on('data_received')
+    def _on_data(packet: rtc.DataPacket):
+        if packet.topic != 'gev.tools':
+            return
+        try:
+            payload = json.loads(packet.data.decode('utf-8'))
+        except Exception:
+            log.warning('Ignoring malformed LiveKit data packet', exc_info=True)
+            return
+        bridge.handle_json(payload)
+
+    tools = build_browser_tools(bridge, load_tools(cfg.tools_path))
+    agent = Agent(
+        instructions=load_instructions(cfg.system_prompt_path),
+        tools=tools,
+        vad=silero.VAD.load(force_cpu=True),
+        stt=build_stt(cfg),
+        llm=build_llm(cfg),
+        tts=build_tts(cfg),
+        min_endpointing_delay=0.25,
+        max_endpointing_delay=0.8,
+        allow_interruptions=True,
+    )
+    session = AgentSession(max_tool_steps=4)
+    await session.start(agent=agent, room=ctx.room)
+
+
+if __name__ == '__main__':
+    cfg = VoiceConfig.from_env()
+    cli.run_app(
+        WorkerOptions(
+            entrypoint_fnc=entrypoint,
+            ws_url=cfg.livekit_url,
+            api_key=cfg.livekit_api_key,
+            api_secret=cfg.livekit_api_secret,
+            agent_name='gev-livekit-voice',
+        )
+    )

--- a/livekit-voice/livekit_voice/config.py
+++ b/livekit-voice/livekit_voice/config.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+
+_ALLOWED_LLM_PROVIDERS = {'ollama', 'vllm', 'openai', 'mock'}
+_ALLOWED_TTS_PROVIDERS = {'piper', 'mock'}
+
+
+def _env(name: str, default: str) -> str:
+    return os.getenv(name, default).strip() or default
+
+
+@dataclass(frozen=True)
+class VoiceConfig:
+    livekit_url: str = 'ws://livekit:7880'
+    livekit_api_key: str = 'devkey'
+    livekit_api_secret: str = 'secret'
+    room_prefix: str = 'gev-voice'
+    llm_provider: str = 'ollama'
+    llm_base_url: str = 'http://ollama:11434/v1'
+    llm_model: str = 'qwen3:8b'
+    llm_api_key: str = 'ollama'
+    stt_base_url: str = 'http://whisper:9000/v1'
+    stt_model: str = 'small'
+    stt_api_key: str = 'local'
+    tts_provider: str = 'piper'
+    tts_base_url: str = 'http://tts:8000/v1'
+    tts_model: str = 'tts-1'
+    tts_voice: str = 'alloy'
+    tts_api_key: str = 'local'
+    tools_path: str = '/app/tools.json'
+    system_prompt_path: str = '/app/system-prompt.txt'
+    tool_timeout_s: float = 20.0
+
+    @classmethod
+    def from_env(cls) -> 'VoiceConfig':
+        cfg = cls(
+            livekit_url=_env('LIVEKIT_URL', cls.livekit_url),
+            livekit_api_key=_env('LIVEKIT_API_KEY', cls.livekit_api_key),
+            livekit_api_secret=_env('LIVEKIT_API_SECRET', cls.livekit_api_secret),
+            room_prefix=_env('GEV_LIVEKIT_ROOM_PREFIX', cls.room_prefix),
+            llm_provider=_env('GEV_LIVEKIT_LLM_PROVIDER', cls.llm_provider),
+            llm_base_url=_env('GEV_LIVEKIT_LLM_BASE_URL', cls.llm_base_url),
+            llm_model=_env('GEV_LIVEKIT_LLM_MODEL', cls.llm_model),
+            llm_api_key=_env('GEV_LIVEKIT_LLM_API_KEY', cls.llm_api_key),
+            stt_base_url=_env('GEV_LIVEKIT_STT_BASE_URL', cls.stt_base_url),
+            stt_model=_env('GEV_LIVEKIT_STT_MODEL', cls.stt_model),
+            stt_api_key=_env('GEV_LIVEKIT_STT_API_KEY', cls.stt_api_key),
+            tts_provider=_env('GEV_LIVEKIT_TTS_PROVIDER', cls.tts_provider),
+            tts_base_url=_env('GEV_LIVEKIT_TTS_BASE_URL', cls.tts_base_url),
+            tts_model=_env('GEV_LIVEKIT_TTS_MODEL', cls.tts_model),
+            tts_voice=_env('GEV_LIVEKIT_TTS_VOICE', cls.tts_voice),
+            tts_api_key=_env('GEV_LIVEKIT_TTS_API_KEY', cls.tts_api_key),
+            tools_path=_env('GEV_LIVEKIT_TOOLS_PATH', cls.tools_path),
+            system_prompt_path=_env('GEV_LIVEKIT_SYSTEM_PROMPT_PATH', cls.system_prompt_path),
+            tool_timeout_s=float(_env('GEV_LIVEKIT_TOOL_TIMEOUT_S', str(cls.tool_timeout_s))),
+        )
+        if cfg.llm_provider not in _ALLOWED_LLM_PROVIDERS:
+            raise ValueError(
+                f'GEV_LIVEKIT_LLM_PROVIDER must be one of {sorted(_ALLOWED_LLM_PROVIDERS)}, got {cfg.llm_provider!r}'
+            )
+        if cfg.tts_provider not in _ALLOWED_TTS_PROVIDERS:
+            raise ValueError(
+                f'GEV_LIVEKIT_TTS_PROVIDER must be one of {sorted(_ALLOWED_TTS_PROVIDERS)}, got {cfg.tts_provider!r}'
+            )
+        return cfg

--- a/livekit-voice/livekit_voice/tool_bridge.py
+++ b/livekit-voice/livekit_voice/tool_bridge.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import asyncio
+import inspect
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Awaitable, Callable
+
+
+class ToolTimeout(TimeoutError):
+    pass
+
+
+SendJson = Callable[[dict[str, Any]], Any | Awaitable[Any]]
+
+
+@dataclass
+class BrowserToolBridge:
+    send_json: SendJson
+    timeout_s: float = 20.0
+    _pending: dict[str, asyncio.Future] = field(default_factory=dict, init=False)
+
+    async def call_tool(self, name: str, arguments: dict[str, Any] | None = None) -> dict[str, Any]:
+        call_id = f'gev-{uuid.uuid4().hex}'
+        loop = asyncio.get_running_loop()
+        future: asyncio.Future = loop.create_future()
+        self._pending[call_id] = future
+
+        payload = {
+            'type': 'gev.tool_call',
+            'call_id': call_id,
+            'name': name,
+            'arguments': arguments or {},
+        }
+        maybe_awaitable = self.send_json(payload)
+        if inspect.isawaitable(maybe_awaitable):
+            await maybe_awaitable
+
+        try:
+            return await asyncio.wait_for(future, timeout=self.timeout_s)
+        except asyncio.TimeoutError as exc:
+            raise ToolTimeout(f'timed out waiting for browser tool result: {name} ({call_id})') from exc
+        finally:
+            self._pending.pop(call_id, None)
+
+    def handle_json(self, payload: dict[str, Any]) -> bool:
+        if payload.get('type') != 'gev.tool_result':
+            return False
+        call_id = payload.get('call_id')
+        future = self._pending.get(call_id)
+        if not future or future.done():
+            return False
+        if 'error' in payload:
+            future.set_result({'ok': False, 'error': str(payload['error'])})
+        else:
+            result = payload.get('result')
+            future.set_result(result if isinstance(result, dict) else {'ok': True, 'result': result})
+        return True

--- a/livekit-voice/requirements.txt
+++ b/livekit-voice/requirements.txt
@@ -1,0 +1,7 @@
+livekit-agents[openai,silero]~=1.2
+livekit-api~=1.0
+livekit-plugins-openai~=1.2
+livekit-plugins-silero~=1.2
+PyJWT~=2.10
+pytest~=8.3
+pytest-asyncio~=0.25

--- a/livekit-voice/system-prompt.txt
+++ b/livekit-voice/system-prompt.txt
@@ -1,0 +1,5 @@
+You are the God's Eye View self-hosted voice copilot.
+
+Keep responses short. Use tools for camera movement, layers, annotations, contacts, map stacks, HUD changes, detection, traffic, CCTV, radio, and analysis. When a request changes the globe or UI, call the matching tool first and only confirm after the browser returns a result. Never claim an action worked unless the tool result has ok=true.
+
+If a tool returns ok=false, say the failure plainly. For counting questions, name the scope from the tool result. For map explanations, prefer visible/geocoded place names over invented coordinates.

--- a/livekit-voice/tests/test_config.py
+++ b/livekit-voice/tests/test_config.py
@@ -1,0 +1,32 @@
+import os
+
+from livekit_voice.config import VoiceConfig
+
+
+def test_voice_config_defaults_are_local_and_cpu_friendly(monkeypatch):
+    for key in list(os.environ):
+        if key.startswith('GEV_') or key.startswith('LIVEKIT_'):
+            monkeypatch.delenv(key, raising=False)
+
+    cfg = VoiceConfig.from_env()
+
+    assert cfg.livekit_url == 'ws://livekit:7880'
+    assert cfg.livekit_api_key == 'devkey'
+    assert cfg.llm_provider == 'ollama'
+    assert cfg.llm_model == 'qwen3:8b'
+    assert cfg.stt_model == 'small'
+    assert cfg.tts_provider == 'piper'
+    assert cfg.tts_model == 'tts-1'
+    assert cfg.tts_voice == 'alloy'
+    assert cfg.room_prefix == 'gev-voice'
+
+
+def test_voice_config_rejects_unknown_llm_provider(monkeypatch):
+    monkeypatch.setenv('GEV_LIVEKIT_LLM_PROVIDER', 'wat')
+
+    try:
+        VoiceConfig.from_env()
+    except ValueError as exc:
+        assert 'GEV_LIVEKIT_LLM_PROVIDER' in str(exc)
+    else:
+        raise AssertionError('expected invalid provider to fail')

--- a/livekit-voice/tests/test_tool_bridge.py
+++ b/livekit-voice/tests/test_tool_bridge.py
@@ -1,0 +1,37 @@
+import asyncio
+
+import pytest
+
+from livekit_voice.tool_bridge import BrowserToolBridge, ToolTimeout
+
+
+@pytest.mark.asyncio
+async def test_bridge_resolves_tool_result_by_call_id():
+    sent = []
+    bridge = BrowserToolBridge(send_json=sent.append, timeout_s=1.0)
+
+    pending = asyncio.create_task(bridge.call_tool('fly_to_location', {'query': 'Tokyo'}))
+    await asyncio.sleep(0)
+
+    assert sent == [{
+        'type': 'gev.tool_call',
+        'call_id': sent[0]['call_id'],
+        'name': 'fly_to_location',
+        'arguments': {'query': 'Tokyo'},
+    }]
+
+    bridge.handle_json({
+        'type': 'gev.tool_result',
+        'call_id': sent[0]['call_id'],
+        'result': {'ok': True, 'arrived': True},
+    })
+
+    assert await pending == {'ok': True, 'arrived': True}
+
+
+@pytest.mark.asyncio
+async def test_bridge_times_out_missing_browser_result():
+    bridge = BrowserToolBridge(send_json=lambda payload: None, timeout_s=0.01)
+
+    with pytest.raises(ToolTimeout):
+        await bridge.call_tool('zoom_to_globe', {})

--- a/livekit-voice/tools.json
+++ b/livekit-voice/tools.json
@@ -1,0 +1,1137 @@
+[
+  {
+    "type": "function",
+    "name": "fly_to_location",
+    "description": "Fly the God's Eye View camera to a known city, geocoded country/region/city/landmark, or explicit WGS84 coordinate. Countries/cities frame the whole place; landmarks/buildings use close framing.",
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "locationId": {
+          "type": "string",
+          "enum": [
+            "austin",
+            "sf",
+            "nyc",
+            "tokyo",
+            "london",
+            "paris",
+            "dubai",
+            "dc"
+          ],
+          "description": "Known city preset ID. Use when the requested place matches one of these cities."
+        },
+        "query": {
+          "type": "string",
+          "description": "Plain place search query, e.g. \"London\", \"Eiffel Tower\", or \"Dubai Marina\"."
+        },
+        "latitude": {
+          "type": "number",
+          "minimum": -90,
+          "maximum": 90
+        },
+        "longitude": {
+          "type": "number",
+          "minimum": -180,
+          "maximum": 180
+        },
+        "viewMode": {
+          "type": "string",
+          "enum": [
+            "close",
+            "overview"
+          ],
+          "description": "Optional framing intent. Usually omit this; GEV infers whole-place framing for countries/cities and close framing for landmarks."
+        },
+        "rangeM": {
+          "type": "number",
+          "minimum": 100,
+          "maximum": 20000000,
+          "description": "Optional camera range from the target in meters. Omit it for automatic whole-country/whole-city or close-landmark framing; provide it only when the user explicitly requests a numeric height or distance."
+        },
+        "waitForArrival": {
+          "type": "boolean",
+          "description": "Set true when a later tool depends on the destination viewport. The result then waits for the camera flight and returns arrived=true; cancellation returns ok=false."
+        }
+      }
+    }
+  },
+  {
+    "type": "function",
+    "name": "select_nearest_aircraft",
+    "description": "Atomically fly to a place, wait for arrival, enable and load Flights or Military Flights in that viewport, exclude on-ground records, and select/follow the nearest airborne aircraft. Healthy fallback feeds remain usable and are reported in the result. This does not open Contacts or Cockpit.",
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "layerId": {
+          "type": "string",
+          "enum": [
+            "flights",
+            "military"
+          ],
+          "description": "Aircraft layer to enable and search. Use flights unless the user explicitly asks for military aircraft."
+        },
+        "locationId": {
+          "type": "string",
+          "enum": [
+            "austin",
+            "sf",
+            "nyc",
+            "tokyo",
+            "london",
+            "paris",
+            "dubai",
+            "dc"
+          ],
+          "description": "Known city preset ID when the place matches one of these cities."
+        },
+        "locationQuery": {
+          "type": "string",
+          "maxLength": 160,
+          "description": "Free-form destination when no locationId matches."
+        },
+        "latitude": {
+          "type": "number",
+          "minimum": -90,
+          "maximum": 90
+        },
+        "longitude": {
+          "type": "number",
+          "minimum": -180,
+          "maximum": 180
+        }
+      },
+      "required": [
+        "layerId"
+      ]
+    }
+  },
+  {
+    "type": "function",
+    "name": "adjust_camera_zoom",
+    "description": "Move the current Cesium camera closer to or farther from what it is presently looking at. Use for relative zoom requests without changing location.",
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "direction": {
+          "type": "string",
+          "enum": [
+            "in",
+            "out"
+          ]
+        },
+        "amount": {
+          "type": "string",
+          "enum": [
+            "little",
+            "medium",
+            "lot"
+          ],
+          "description": "Use little for phrases like \"a bit\" or \"a little\", medium for ordinary zoom requests, and lot for \"way out/in\"."
+        }
+      },
+      "required": [
+        "direction",
+        "amount"
+      ]
+    }
+  },
+  {
+    "type": "function",
+    "name": "zoom_to_globe",
+    "description": "Pull the camera out to an ABSOLUTE full-Earth globe view (~18,000 km altitude, the whole planet in frame), keeping the current region centered. Use for \"globe view\", \"whole earth\", \"see the planet\", \"zoom all the way out\". Never use adjust_camera_zoom for these — its relative steps cannot reach the globe.",
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {}
+    }
+  },
+  {
+    "type": "function",
+    "name": "set_layer_visibility",
+    "description": "Enable or disable one registered God's Eye View data layer.",
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "layerId": {
+          "type": "string",
+          "description": "Common-name mapping for the non-obvious ids: space mission(s) → rocket-launches; fires/wildfires/active fires → local-firms (NASA FIRMS); ships/vessels/boats → ais-live-vessels; undersea/submarine cables → telegeography-submarine-cables; datacenters → local-datacenters; dams → local-dams; bikes/bike share → bikeshare; street traffic/congestion → traffic; traffic cameras → cctv; internet radio/stations → radio.",
+          "enum": [
+            "flights",
+            "military",
+            "earthquakes",
+            "satellites",
+            "rocket-launches",
+            "traffic",
+            "cctv",
+            "radio",
+            "bikeshare",
+            "ais-live-vessels",
+            "local-datacenters",
+            "local-dams",
+            "telegeography-submarine-cables",
+            "local-firms"
+          ]
+        },
+        "enabled": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "layerId",
+        "enabled"
+      ]
+    }
+  },
+  {
+    "type": "function",
+    "name": "show_data_layers_menu",
+    "description": "Open the data layers dropdown/menu and optionally scroll to a specific layer row without toggling it.",
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "layerId": {
+          "type": "string",
+          "enum": [
+            "flights",
+            "military",
+            "earthquakes",
+            "satellites",
+            "traffic",
+            "cctv",
+            "radio",
+            "bikeshare",
+            "ais-live-vessels",
+            "local-datacenters",
+            "local-dams",
+            "telegeography-submarine-cables",
+            "local-firms"
+          ],
+          "description": "Optional layer row to scroll into view and highlight."
+        }
+      }
+    }
+  },
+  {
+    "type": "function",
+    "name": "set_panel_open",
+    "description": "Open or close a GEV UI panel/dropdown.",
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "panelId": {
+          "type": "string",
+          "enum": [
+            "data-panel",
+            "location-bar",
+            "control-panel",
+            "cctv-panel",
+            "radio-panel",
+            "scene-panel",
+            "pp-toggles",
+            "global-context-panel"
+          ]
+        },
+        "open": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "panelId",
+        "open"
+      ]
+    }
+  },
+  {
+    "type": "function",
+    "name": "set_context_mode",
+    "description": "Enter or exit the Global Context sub-mode used by Contacts and Space Missions. Use Contacts only when the user explicitly requests Contacts, and Space Missions only when explicitly requested. A request to open the parent Context panel alone uses set_panel_open and must not activate either sub-mode. Selecting an aircraft does not imply Context.",
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "mode": {
+          "type": "string",
+          "enum": [
+            "off",
+            "contacts",
+            "flights",
+            "space-missions",
+            "missions"
+          ],
+          "description": "Use off to exit context mode."
+        }
+      },
+      "required": [
+        "mode"
+      ]
+    }
+  },
+  {
+    "type": "function",
+    "name": "control_cockpit",
+    "description": "Read or control Cockpit when the user explicitly requests Cockpit: establish Contacts and enter from a selected or tracked aircraft; exit; or navigate nearby Contacts with optional filters. Selecting or viewing an aircraft alone must not enter Cockpit.",
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "action": {
+          "type": "string",
+          "enum": [
+            "enter",
+            "exit",
+            "previous",
+            "next",
+            "prev",
+            "status"
+          ],
+          "description": "previous/next (or prev) navigates through nearby contacts in Cockpit context."
+        },
+        "targetLayer": {
+          "type": "string",
+          "enum": [
+            "flights",
+            "military",
+            "ais-live-vessels",
+            "military-installations"
+          ],
+          "description": "Optional contact layer filter for next/previous (for example military for a military-only cycle)."
+        },
+        "aircraftClass": {
+          "type": "string",
+          "description": "Optional aircraft class filter (for example helicopter) when using next/previous navigation."
+        }
+      },
+      "required": [
+        "action"
+      ]
+    }
+  },
+  {
+    "type": "function",
+    "name": "set_visual_style",
+    "description": "Set the active God's Eye View visual filter/style.",
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "style": {
+          "type": "string",
+          "enum": [
+            "normal",
+            "retro",
+            "surveillance",
+            "thermal",
+            "anime",
+            "noir",
+            "snow"
+          ]
+        }
+      },
+      "required": [
+        "style"
+      ]
+    }
+  },
+  {
+    "type": "function",
+    "name": "get_entity_context",
+    "description": "Get current GEV scene context, including basemap/3D-tile target context, selected entity metadata if active, and entities currently visible in the camera view.",
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "scope": {
+          "type": "string",
+          "enum": [
+            "auto",
+            "selected",
+            "in_view"
+          ],
+          "description": "Use auto by default. selected returns the clicked/selected entity; in_view returns visible entities near the screen center."
+        },
+        "layerId": {
+          "type": "string",
+          "enum": [
+            "local-datacenters",
+            "local-dams",
+            "telegeography-submarine-cables",
+            "local-firms"
+          ],
+          "description": "Optional layer filter for visible entity context."
+        },
+        "limit": {
+          "type": "number",
+          "minimum": 1,
+          "maximum": 12
+        }
+      }
+    }
+  },
+  {
+    "type": "function",
+    "name": "get_current_view_state",
+    "description": "Read the current camera, style, Context, Cockpit, HUD, detection, map stack, post-processing, scene-playback, tracked-entity, and layer state before choosing another action.",
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {}
+    }
+  },
+  {
+    "type": "function",
+    "name": "set_hud",
+    "description": "Control the intelligence HUD overlay: visibility and/or layout variant.",
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "visible": {
+          "type": "string",
+          "enum": [
+            "on",
+            "off",
+            "auto"
+          ],
+          "description": "auto restores style-driven show/hide."
+        },
+        "layout": {
+          "type": "string",
+          "enum": [
+            "tactical",
+            "operator",
+            "minimal"
+          ]
+        }
+      }
+    }
+  },
+  {
+    "type": "function",
+    "name": "set_detection",
+    "description": "Control the detection overlay: on/off, density-derived Sparse/Balanced/Dense profile, and Elastic/Weighted layer allocation.",
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "false turns detection OFF; true restores the current density-derived profile."
+        },
+        "mode": {
+          "type": "string",
+          "enum": [
+            "sparse",
+            "balanced",
+            "dense"
+          ]
+        },
+        "densityPct": {
+          "type": "number",
+          "description": "Density snaps to 0, 25, 50, 75, or 100 and derives the active profile."
+        },
+        "allocationStrategy": {
+          "type": "string",
+          "enum": [
+            "elastic",
+            "weighted"
+          ],
+          "description": "Elastic splits evenly then lends unused slots; Weighted follows demand and semantic weight."
+        }
+      }
+    }
+  },
+  {
+    "type": "function",
+    "name": "set_map_stack",
+    "description": "Switch the basemap/imagery stack (NOT the satellites data layer and NOT a visual style filter).",
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "stack": {
+          "type": "string",
+          "enum": [
+            "photoreal",
+            "bing-aerial",
+            "bing-labels",
+            "osm"
+          ],
+          "description": "photoreal = Google 3D. Use bing-aerial only when the user explicitly says \"Bing aerial\" — \"satellite(s)\" never means a basemap."
+        }
+      },
+      "required": [
+        "stack"
+      ]
+    }
+  },
+  {
+    "type": "function",
+    "name": "set_post_processing",
+    "description": "Control bloom and sharpen post-processing toggles and intensities.",
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "bloom": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "intensityPct": {
+              "type": "number",
+              "description": "0-200 (UI percent)."
+            }
+          }
+        },
+        "sharpen": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "intensityPct": {
+              "type": "number",
+              "description": "0-100 (UI percent)."
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    "type": "function",
+    "name": "control_scene",
+    "description": "Cinematic scene playback: list scenes, play one scene by name, stop, advance, or read status. Play starts a single named scene and returns immediately.",
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "action": {
+          "type": "string",
+          "enum": [
+            "list",
+            "play",
+            "stop",
+            "next",
+            "status"
+          ]
+        },
+        "sceneId": {
+          "type": "string",
+          "description": "Scene id or (partial) title for play."
+        }
+      },
+      "required": [
+        "action"
+      ]
+    }
+  },
+  {
+    "type": "function",
+    "name": "control_cctv",
+    "description": "CCTV camera operations: enable/disable the layer, select a camera by name, next/prev/nearest/focus, toggle coverage wedges / projection overlay / auto-hop, \"viewshed\" for color-coded per-camera coverage volumes, and \"adjust\" for the on-camera calibration gizmo.",
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "action": {
+          "type": "string",
+          "enum": [
+            "enable",
+            "disable",
+            "select",
+            "next",
+            "prev",
+            "nearest",
+            "focus",
+            "coverage",
+            "viewshed",
+            "adjust",
+            "projection",
+            "autohop"
+          ]
+        },
+        "cameraQuery": {
+          "type": "string",
+          "description": "Camera name or id for select."
+        },
+        "enabled": {
+          "type": "boolean",
+          "description": "Explicit on/off for coverage/viewshed/adjust/projection/autohop; omit to toggle."
+        }
+      },
+      "required": [
+        "action"
+      ]
+    }
+  },
+  {
+    "type": "function",
+    "name": "control_radio",
+    "description": "Control Internet Radio playback without moving the map. Use select whenever the request includes a station category, name, country, coordinates, or nearby place—even when the user says play. Use play only for an unqualified \"turn on/start the radio\" request so the current or nearest station begins. Enable only reveals the Radio layer/markers without audio. Also supports disable, resume, pause, stop, next/previous, volume, and status.",
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "action": {
+          "type": "string",
+          "enum": [
+            "enable",
+            "disable",
+            "play",
+            "resume",
+            "pause",
+            "stop",
+            "next",
+            "previous",
+            "volume",
+            "select",
+            "status"
+          ],
+          "description": "Use select for any request qualified by category, station, country, coordinates, or place. Use play only for an unqualified turn on/start/listen request. Use enable only when the user explicitly asks to show or enable the Radio layer or its markers without requesting audio."
+        },
+        "volumePct": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 100,
+          "description": "Required for volume; sets the persistent Radio playback volume."
+        },
+        "category": {
+          "type": "string",
+          "enum": [
+            "all",
+            "news",
+            "talk",
+            "weather",
+            "public-safety",
+            "aviation-marine",
+            "traffic-transit",
+            "music"
+          ],
+          "description": "Station category for select/next/previous. When the user requests playback with a category, action must be select, not play."
+        },
+        "locationId": {
+          "type": "string",
+          "enum": [
+            "austin",
+            "sf",
+            "nyc",
+            "tokyo",
+            "london",
+            "paris",
+            "dubai",
+            "dc"
+          ],
+          "description": "Known nearby-city anchor for select."
+        },
+        "locationQuery": {
+          "type": "string",
+          "maxLength": 120,
+          "description": "Place to search near, such as \"Austin, Texas\" or \"Seattle\". Selection does not fly the camera."
+        },
+        "latitude": {
+          "type": "number",
+          "minimum": -90,
+          "maximum": 90
+        },
+        "longitude": {
+          "type": "number",
+          "minimum": -180,
+          "maximum": 180
+        },
+        "country": {
+          "type": "string",
+          "maxLength": 80,
+          "description": "Country code or name filter, for example US or United States."
+        },
+        "stationQuery": {
+          "type": "string",
+          "maxLength": 120,
+          "description": "Optional station name/tag substring."
+        }
+      },
+      "required": [
+        "action"
+      ]
+    }
+  },
+  {
+    "type": "function",
+    "name": "track_entity",
+    "description": "Find and follow a specific aircraft (callsign/ICAO hex), ship (name/MMSI), or satellite (name/NORAD id) on enabled layers. Camera follows the entity.",
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "query": {
+          "type": "string",
+          "description": "Callsign, ship name, satellite name, ICAO hex, MMSI, or NORAD id."
+        },
+        "layerId": {
+          "type": "string",
+          "description": "Optional layer hint: flights | military | ais-live-vessels | satellites."
+        }
+      },
+      "required": [
+        "query"
+      ]
+    }
+  },
+  {
+    "type": "function",
+    "name": "stop_tracking",
+    "description": "Stop following the tracked aircraft/satellite and clear any selected vessel.",
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {}
+    }
+  },
+  {
+    "type": "function",
+    "name": "frame_overhead",
+    "description": "Cinematically frame entities near the current view: pulls the camera back and angles it so nearby aircraft, ships, or satellites are visible together.",
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "target": {
+          "type": "string",
+          "enum": [
+            "flights",
+            "military",
+            "satellites",
+            "vessels"
+          ]
+        },
+        "radiusKm": {
+          "type": "number",
+          "description": "Search radius around the view target. Defaults: 150 aircraft, 120 ships, 3000 satellites."
+        }
+      },
+      "required": [
+        "target"
+      ]
+    }
+  },
+  {
+    "type": "function",
+    "name": "annotate_map",
+    "description": "Draw annotations on the 3D map to visually point out what you are talking about — like sketching on a whiteboard over the world. Use this whenever you mention a specific place, building, campus, boundary, district, or a relationship between two places, so the user can SEE what you mean. Give place NAMES (preferred) or explicit lat/lng; the app resolves them to real-world positions and real building/area outlines — never guess pixel positions. Call this as you begin describing something, and you may mark several places in one call.",
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "annotations": {
+          "type": "array",
+          "description": "One or more things to mark. Mark multiple related places together when describing them as a group.",
+          "minItems": 1,
+          "maxItems": 24,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "pin",
+                  "highlight",
+                  "area",
+                  "arrow",
+                  "route",
+                  "label"
+                ],
+                "description": "pin = planted marker at a spot; highlight = pulsing ring drawing the eye to a point; area = trace the outline of a building/campus/compound/district; arrow = a connector from one place to another (use target as the origin and toTarget as the destination); route = a path through several waypoints (use the points array); label = a floating text callout."
+              },
+              "target": {
+                "type": "string",
+                "maxLength": 200,
+                "description": "Place name to resolve, e.g. \"Palace of Fine Arts, San Francisco\", \"the Pentagon\", \"Presidio of San Francisco\". Preferred over coordinates. For a specific monument/statue/feature that sits within a larger landmark, use its OWN name + city (\"Tejano Monument, Austin\", \"Texas African American History Memorial, Austin\") — do NOT phrase it as \"X at the Texas State Capitol\", which makes the geocoder collapse several of them onto the same centroid so they stack on one spot."
+              },
+              "points": {
+                "type": "array",
+                "description": "For type=route: 2+ ordered waypoints the path passes through, each a place name (or coordinates / screen point).",
+                "minItems": 2,
+                "maxItems": 12,
+                "items": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "target": {
+                      "type": "string",
+                      "maxLength": 200,
+                      "description": "Waypoint place name."
+                    },
+                    "latitude": {
+                      "type": "number",
+                      "minimum": -90,
+                      "maximum": 90
+                    },
+                    "longitude": {
+                      "type": "number",
+                      "minimum": -180,
+                      "maximum": 180
+                    },
+                    "screenX": {
+                      "type": "number",
+                      "minimum": 0,
+                      "maximum": 1
+                    },
+                    "screenY": {
+                      "type": "number",
+                      "minimum": 0,
+                      "maximum": 1
+                    }
+                  }
+                }
+              },
+              "mode": {
+                "type": "string",
+                "enum": [
+                  "walking",
+                  "driving",
+                  "cycling"
+                ],
+                "description": "For type=route: travel mode for a real street-following route (the app returns distance + time). Pick from the verb the user used (\"walk\" → walking, \"drive\" → driving). Defaults to walking."
+              },
+              "latitude": {
+                "type": "number",
+                "minimum": -90,
+                "maximum": 90,
+                "description": "Explicit latitude (use only if no good place name exists)."
+              },
+              "longitude": {
+                "type": "number",
+                "minimum": -180,
+                "maximum": 180
+              },
+              "toTarget": {
+                "type": "string",
+                "maxLength": 200,
+                "description": "For type=arrow: the destination place name."
+              },
+              "toLatitude": {
+                "type": "number",
+                "minimum": -90,
+                "maximum": 90
+              },
+              "toLongitude": {
+                "type": "number",
+                "minimum": -180,
+                "maximum": 180
+              },
+              "label": {
+                "type": "string",
+                "maxLength": 120,
+                "description": "Short caption shown on the map (a few words). Optional."
+              },
+              "color": {
+                "type": "string",
+                "enum": [
+                  "primary",
+                  "amber",
+                  "cyan",
+                  "green",
+                  "red"
+                ],
+                "description": "Accent color. primary = neutral, amber = point of interest, cyan = infrastructure, green = confirmed/safe, red = alert."
+              },
+              "footprint": {
+                "type": "boolean",
+                "description": "For type=area/highlight: trace the real building or campus outline from map data. Defaults true for area."
+              },
+              "intent": {
+                "type": "string",
+                "enum": [
+                  "the_thing",
+                  "around_the_thing"
+                ],
+                "description": "For type=area: \"the_thing\" (default) outlines the place itself (its footprint/boundary); \"around_the_thing\" highlights a surrounding zone (a buffered radius around it). Infer from phrasing: \"the Capitol\"/\"show me X\" → the_thing; \"around/near/by X\" or \"the area around X\" → around_the_thing."
+              },
+              "entityKind": {
+                "type": "string",
+                "enum": [
+                  "building",
+                  "compound",
+                  "district",
+                  "street",
+                  "point_feature"
+                ],
+                "description": "What KIND of thing the target IS — a fact, not a style choice: building = one structure; compound = campus/grounds/mall/park; district = neighborhood or area of a city; street = a named road/corridor; point_feature = monument/statue/memorial/plaque/fountain or other small point landmark. Set it whenever you know it — it routes the resolver to the right footprint source (point_feature anchors monuments as precise points instead of adopting a nearby building outline)."
+              },
+              "screenX": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1,
+                "description": "Fallback only: when you cannot name/geocode the place but can SEE it in the latest viewport screenshot, the normalized horizontal position (0=left, 1=right) of the spot. The app converts it back to a real world point under that pixel."
+              },
+              "screenY": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1,
+                "description": "Fallback only: normalized vertical position (0=top, 1=bottom) of the spot in the latest viewport screenshot."
+              },
+              "toScreenX": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1,
+                "description": "For type=arrow: normalized x of the arrow destination from the screenshot (pixel fallback)."
+              },
+              "toScreenY": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1,
+                "description": "For type=arrow: normalized y of the arrow destination from the screenshot (pixel fallback)."
+              }
+            },
+            "required": [
+              "type"
+            ]
+          }
+        },
+        "flyTo": {
+          "type": "boolean",
+          "description": "Also move the camera to frame the first annotation. Default false — leave false if the user is already looking at the spot."
+        },
+        "persist": {
+          "type": "boolean",
+          "description": "Keep annotations until cleared (true, default) or let them auto-fade after ~20s (false)."
+        }
+      },
+      "required": [
+        "annotations"
+      ]
+    }
+  },
+  {
+    "type": "function",
+    "name": "clear_annotations",
+    "description": "Erase ALL map annotations previously drawn with annotate_map. Call this ONLY when the user EXPLICITLY asks to clear or reset the map. Annotations accumulate and persist across navigation and topic changes by design — never clear on your own initiative.",
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {}
+    }
+  },
+  {
+    "type": "function",
+    "name": "move_camera",
+    "description": "Direct the camera like a drone operator: orbit the current view target, pan, tilt, or rotate — one bounded nudge (mode=once) or continuous motion until stopped (mode=continuous). Continuous motion also stops on any manual camera input or when a navigation tool runs. Say the RESULTING state when confirming (\"Orbiting slowly\").",
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "motion": {
+          "type": "string",
+          "enum": [
+            "orbit",
+            "pan",
+            "tilt",
+            "rotate",
+            "stop"
+          ]
+        },
+        "direction": {
+          "type": "string",
+          "enum": [
+            "left",
+            "right",
+            "up",
+            "down"
+          ],
+          "description": "Required except for orbit (defaults right/clockwise) and stop."
+        },
+        "speed": {
+          "type": "string",
+          "enum": [
+            "slow",
+            "normal",
+            "fast"
+          ]
+        },
+        "mode": {
+          "type": "string",
+          "enum": [
+            "once",
+            "continuous"
+          ],
+          "description": "once = bounded eased nudge (default); continuous = until stop/manual input."
+        }
+      },
+      "required": [
+        "motion"
+      ]
+    }
+  },
+  {
+    "type": "function",
+    "name": "fly_route",
+    "description": "Cinematic dolly along an EXISTING route annotation (drawn earlier with annotate_map type=route) — flies the street-following path from start to end. Omit label for the newest route. If no route is drawn, this fails with guidance: draw the route first.",
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "type": "string",
+          "description": "Match an existing route mark by (partial) label."
+        },
+        "speed": {
+          "type": "string",
+          "enum": [
+            "slow",
+            "normal",
+            "fast"
+          ]
+        }
+      }
+    }
+  },
+  {
+    "type": "function",
+    "name": "analyst_query",
+    "description": "Answer questions ABOUT the data currently loaded on the map — counts, lists, superlatives, and attribute filters over live layers (flights, military, ships, fires, earthquakes). Examples: \"how many flights over Texas\", \"biggest fire near LA\", \"which ships are headed to Oakland\", \"anything above 40,000 feet\", \"fastest thing in view\". Queries ONLY client-side data from ENABLED layers — if the needed layer is off, say so and offer to enable it. For a follow-up about the previous answer's set (\"which of those is closest?\"), set followUp=true and send only the new filters/sort.",
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "layers": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "flights",
+              "military",
+              "ais-live-vessels",
+              "local-firms",
+              "earthquakes"
+            ]
+          },
+          "description": "Layers to query. fires/wildfires → local-firms; ships/vessels → ais-live-vessels."
+        },
+        "scope": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Spatial scope. Default: view (near the camera). Use kind=region for \"over Texas\"-style asks; kind=anywhere for global questions.",
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": [
+                "view",
+                "region",
+                "radius",
+                "anywhere"
+              ]
+            },
+            "name": {
+              "type": "string",
+              "description": "For kind=region: a state/country (\"Texas\", \"France\") or a named natural region (\"the Alps\", \"Gulf of Mexico\")."
+            },
+            "km": {
+              "type": "number",
+              "description": "For kind=radius."
+            },
+            "center": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "lat": {
+                  "type": "number"
+                },
+                "lon": {
+                  "type": "number"
+                }
+              }
+            }
+          }
+        },
+        "filters": {
+          "type": "array",
+          "description": "Attribute predicates, ANDed. ALTITUDE IS METERS (40,000 ft = 12192). Fields: altitudeM, speedMps, military, onGround, aircraftClass, callsign, operator, routeOrigin, routeDestination, originCountry (flights); speedKts, shipType, destination (ships); frp, confidence (fires); magnitude, depthKm, place (earthquakes).",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "field": {
+                "type": "string"
+              },
+              "op": {
+                "type": "string",
+                "enum": [
+                  "gt",
+                  "gte",
+                  "lt",
+                  "lte",
+                  "eq",
+                  "neq",
+                  "contains"
+                ]
+              },
+              "value": {}
+            },
+            "required": [
+              "field",
+              "op",
+              "value"
+            ]
+          }
+        },
+        "sortBy": {
+          "type": "string",
+          "description": "Field to rank by, or \"distance\" for nearest-first."
+        },
+        "sortDir": {
+          "type": "string",
+          "enum": [
+            "asc",
+            "desc"
+          ]
+        },
+        "limit": {
+          "type": "number"
+        },
+        "followUp": {
+          "type": "boolean",
+          "description": "true = re-query the PREVIOUS result set instead of fresh data."
+        }
+      }
+    }
+  },
+  {
+    "type": "function",
+    "name": "next_iss_pass",
+    "description": "When the user asks when the ISS / the space station will next fly over: returns the next visible ISS pass for the current camera location (or an explicit lat/lon) — rise time (ISO + minutes from now), rise compass direction, peak elevation, and duration. Requires the satellites layer to have loaded its catalog at least once this session; if it hasn't, tell the user to enable the satellites layer and try again.",
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "latitude": {
+          "type": "number",
+          "minimum": -90,
+          "maximum": 90,
+          "description": "Optional observer latitude. Omit to use the current camera position."
+        },
+        "longitude": {
+          "type": "number",
+          "minimum": -180,
+          "maximum": 180,
+          "description": "Optional observer longitude. Omit to use the current camera position."
+        },
+        "minElevationDeg": {
+          "type": "number",
+          "minimum": 5,
+          "maximum": 60,
+          "description": "Minimum peak elevation (deg) to count as a pass. Default 10."
+        }
+      }
+    }
+  }
+]

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@mapbox/vector-tile": "^3.0.0",
         "cesium": "^1.124.0",
         "egm96-universal": "^1.1.1",
+        "livekit-client": "^2.22.0",
         "mgrs": "^2.1.0",
         "pbf": "^5.1.2",
         "satellite.js": "^6.0.2"
@@ -51,6 +52,12 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.10.1.tgz",
+      "integrity": "sha512-wJ8ReQbHxsAfXhrf9ixl0aYbZorRuOWpBNzm8pL8ftmSxQx/wnJD5Eg861NwJU/czy2VXFIebCeZnZrI9rktIQ==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@cesium/engine": {
       "version": "22.3.0",
@@ -1046,6 +1053,21 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@livekit/mutex": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@livekit/mutex/-/mutex-1.1.1.tgz",
+      "integrity": "sha512-EsshAucklmpuUAfkABPxJNhzj9v2sG7JuzFDL4ML1oJQSV14sqrpTYnsaOudMAw9yOaW53NU3QQTlUQoRs4czw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@livekit/protocol": {
+      "version": "1.50.4",
+      "resolved": "https://registry.npmjs.org/@livekit/protocol/-/protocol-1.50.4.tgz",
+      "integrity": "sha512-L1uggNQAqyY21smQY8AllyOYbcv9Me9TaxwuLytL1R8ck9nbYPmQLNwEDi3pOFGAMa5F8I2nUi2Jc59W5awxlA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@bufbuild/protobuf": "^1.10.0"
+      }
+    },
     "node_modules/@mapbox/point-geometry": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-1.1.0.tgz",
@@ -1502,6 +1524,13 @@
       "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-25.0.0.tgz",
       "integrity": "sha512-XKLA6syeBUaPzx4j3qwMqzzq+V4uo72BnlbOjmuljLrRqdsd3qnzvZZoxvMHZ23ndsRS4aufU6JOZYpCbU6T1A==",
       "license": "MIT"
+    },
+    "node_modules/@types/dom-mediacapture-record": {
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/@types/dom-mediacapture-record/-/dom-mediacapture-record-1.0.22.tgz",
+      "integrity": "sha512-mUMZLK3NvwRLcAAT9qmcK+9p7tpU2FHdDsntR3YI4+GY88XrgG4XiE7u1Q2LAN2/FZOz/tdMDC3GQCR4T8nFuw==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/estree": {
       "version": "1.0.9",
@@ -2196,6 +2225,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/events-universal": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
@@ -2539,6 +2577,15 @@
         "@types/estree": "*"
       }
     },
+    "node_modules/jose": {
+      "version": "6.2.10",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.10.tgz",
+      "integrity": "sha512-iiW7J9qRFlGxvCOIBDBDxFePQSn7ZMAnrYGhrrOo6siO/MIqwfyilLR27pkfDgUk+raLuzADS8A3S/KLBisc0g==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -2622,6 +2669,39 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/livekit-client": {
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/livekit-client/-/livekit-client-2.22.0.tgz",
+      "integrity": "sha512-GLtYQfRh/RsvXaOX1x609bFZ17yyKmKWDqu9JmkMKn9vIFLi2GsapRv9gT8OJO/1R2dsitrkbGmloyUfxWQsaA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@livekit/mutex": "1.1.1",
+        "@livekit/protocol": "1.50.4",
+        "events": "^3.3.0",
+        "jose": "^6.1.0",
+        "loglevel": "^1.9.2",
+        "sdp-transform": "^2.15.0",
+        "tslib": "2.8.1",
+        "typed-emitter": "^2.1.0",
+        "webrtc-adapter": "9.0.6"
+      },
+      "peerDependencies": {
+        "@types/dom-mediacapture-record": "^1"
+      }
+    },
+    "node_modules/loglevel": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz",
+      "integrity": "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "funding": {
+        "type": "tidelift",
+        "url": "https://tidelift.com/funding/github/npm/loglevel"
+      }
     },
     "node_modules/long": {
       "version": "5.3.2",
@@ -3168,11 +3248,36 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/satellite.js": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/satellite.js/-/satellite.js-6.0.2.tgz",
       "integrity": "sha512-XWKxtqVF5xiJ1xAeiYeT/oSSzsukoCLWvk6nO/WFy4un0M3g4djAU9TAtOCqJLtYW9vxx9pkPJ1L9ITOc607GA==",
       "license": "MIT"
+    },
+    "node_modules/sdp": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/sdp/-/sdp-3.2.2.tgz",
+      "integrity": "sha512-xZocWwfyp4hkbN4hLWxMjmv2Q8aNa9MhmOZ7L9aCZPT+dZsgRr6wZRrSYE3HTdyk/2pZKPSgqI7ns7Een1xMSA==",
+      "license": "MIT"
+    },
+    "node_modules/sdp-transform": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/sdp-transform/-/sdp-transform-2.15.0.tgz",
+      "integrity": "sha512-KrOH82c/W+GYQ0LHqtr3caRpM3ITglq3ljGUIb8LTki7ByacJZ9z+piSGiwZDsRyhQbYBOBJgr2k6X4BZXi3Kw==",
+      "license": "MIT",
+      "bin": {
+        "sdp-verify": "checker.js"
+      }
     },
     "node_modules/semver": {
       "version": "7.7.4",
@@ -3513,6 +3618,15 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
+    "node_modules/typed-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/typed-emitter/-/typed-emitter-2.1.0.tgz",
+      "integrity": "sha512-g/KzbYKbH5C2vPkaXGu8DJlHrGKHLsM25Zg9WuC9pMGfuvT+X25tZQWo5fK1BjBm8+UrVE9LDCvaY0CQk+fXDA==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "rxjs": "*"
+      }
+    },
     "node_modules/typed-query-selector": {
       "version": "2.12.0",
       "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.0.tgz",
@@ -3680,6 +3794,19 @@
       "integrity": "sha512-ARrjNjtWRRs2w4Tk7nqrf2gBI0QXWuOmMCx2hU+1jUt6d00MjMxURrhxhGbrsoiZKJrhTSTzbIrc554iKI10qw==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/webrtc-adapter": {
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/webrtc-adapter/-/webrtc-adapter-9.0.6.tgz",
+      "integrity": "sha512-CHbl2ZQbxx164IgWRgzJno4hWtM4tFbRam1QfI3Yxhs3w/DvqluVxVWeXs3oL5/fbGkSNLKo0Ty5MgUWceNhog==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "sdp": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=6.0.0",
+        "npm": ">=3.10.0"
+      }
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -39,12 +39,14 @@
     "preview": "vite preview",
     "test": "node scripts/run-unit-tests.mjs",
     "test:track": "node scripts/track-regression.mjs",
-    "qa:map-source-tray": "node scripts/qa-map-source-tray.mjs"
+    "qa:map-source-tray": "node scripts/qa-map-source-tray.mjs",
+    "livekit:tools": "node scripts/export-realtime-tools.mjs ."
   },
   "dependencies": {
     "@mapbox/vector-tile": "^3.0.0",
     "cesium": "^1.124.0",
     "egm96-universal": "^1.1.1",
+    "livekit-client": "^2.22.0",
     "mgrs": "^2.1.0",
     "pbf": "^5.1.2",
     "satellite.js": "^6.0.2"

--- a/scripts/export-realtime-tools.mjs
+++ b/scripts/export-realtime-tools.mjs
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const MARKER = 'const GEV_REALTIME_TOOLS = [';
+
+export function extractRealtimeTools(source) {
+  const markerStart = source.indexOf(MARKER);
+  if (markerStart < 0) {
+    throw new Error('GEV_REALTIME_TOOLS literal not found in vite.config.js');
+  }
+  const arrayStart = source.indexOf('[', markerStart);
+  if (arrayStart < 0) {
+    throw new Error('GEV_REALTIME_TOOLS array start not found');
+  }
+
+  let depth = 0;
+  let inString = null;
+  let escaped = false;
+  let inLineComment = false;
+  let inBlockComment = false;
+
+  for (let i = arrayStart; i < source.length; i += 1) {
+    const char = source[i];
+    const next = source[i + 1];
+
+    if (inLineComment) {
+      if (char === '\n') inLineComment = false;
+      continue;
+    }
+    if (inBlockComment) {
+      if (char === '*' && next === '/') {
+        inBlockComment = false;
+        i += 1;
+      }
+      continue;
+    }
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === '\\') {
+        escaped = true;
+      } else if (char === inString) {
+        inString = null;
+      }
+      continue;
+    }
+
+    if (char === '/' && next === '/') {
+      inLineComment = true;
+      i += 1;
+      continue;
+    }
+    if (char === '/' && next === '*') {
+      inBlockComment = true;
+      i += 1;
+      continue;
+    }
+    if (char === '\'' || char === '"' || char === '`') {
+      inString = char;
+      continue;
+    }
+    if (char === '[') depth += 1;
+    if (char === ']') {
+      depth -= 1;
+      if (depth === 0) {
+        const literal = source.slice(arrayStart, i + 1);
+        // The literal is trusted local source from this repository. Evaluating only
+        // the bracketed array keeps imports and server code out of the export path.
+        const tools = Function(`"use strict"; return (${literal});`)();
+        if (!Array.isArray(tools)) throw new Error('GEV_REALTIME_TOOLS did not evaluate to an array');
+        return tools;
+      }
+    }
+  }
+  throw new Error('GEV_REALTIME_TOOLS array end not found');
+}
+
+export function writeRealtimeTools({ rootDir = process.cwd() } = {}) {
+  const viteConfigPath = join(rootDir, 'vite.config.js');
+  const outputPath = join(rootDir, 'livekit-voice', 'tools.json');
+  const tools = extractRealtimeTools(readFileSync(viteConfigPath, 'utf8'));
+  mkdirSync(dirname(outputPath), { recursive: true });
+  writeFileSync(outputPath, `${JSON.stringify(tools, null, 2)}\n`);
+  return { outputPath, count: tools.length };
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const rootDir = process.argv[2] || process.cwd();
+  const result = writeRealtimeTools({ rootDir });
+  console.log(`Wrote ${result.count} tools to ${result.outputPath}`);
+}

--- a/src/firstRunExperience.js
+++ b/src/firstRunExperience.js
@@ -401,6 +401,7 @@ export function initFirstRunExperience({
     rememberFirstRunSessionDismissed(sessionStorageRef);
     root.classList.remove('visible');
     root.setAttribute('aria-hidden', 'true');
+    documentRef.body?.classList?.remove('first-run-focus');
     documentRef.removeEventListener('keydown', onKeyDown, true);
     globalThis.removeEventListener?.('resize', onViewportResize);
     surfaceObserver?.disconnect();
@@ -561,6 +562,7 @@ export function initFirstRunExperience({
     if (revealed || closing) return;
     revealed = true;
     root.hidden = false;
+    documentRef.body?.classList?.add('first-run-focus');
     globalThis.requestAnimationFrame?.(() => {
       if (closing) return;
       root.classList.add('visible');

--- a/src/firstRunExperience.test.mjs
+++ b/src/firstRunExperience.test.mjs
@@ -178,6 +178,25 @@ test('no storage is touched from a default parameter position', () => {
   assert.match(code, /function writeStored\(kind, injected, key, value\)/);
 });
 
+test('first-run focus class gates the onboarding-only quiet UI state', () => {
+  const module = fs.readFileSync(new URL('./firstRunExperience.js', import.meta.url), 'utf8');
+  const css = fs.readFileSync(new URL('../style.css', import.meta.url), 'utf8');
+
+  assert.match(module, /documentRef\.body\?\.classList\?\.add\('first-run-focus'\)/);
+  assert.match(module, /documentRef\.body\?\.classList\?\.remove\('first-run-focus'\)/);
+  assert.match(css, /body\.first-run-focus #first-run-launcher/);
+  for (const selector of [
+    '#left-panel-stack',
+    '#right-context-rail',
+    '#command-dock',
+    '#intel-hud',
+    '#traffic-sync-chip',
+    '#cctv-sync-chip',
+  ]) {
+    assert.match(css, new RegExp(`body\\.first-run-focus ${selector.replace('#', '#')}`));
+  }
+});
+
 // ── ESC arbitration: one surface, one key, never an invisible handler ────────
 
 test('the JS and CSS lists of screen-claiming surfaces stay in step', () => {

--- a/src/livekitToolsExport.test.mjs
+++ b/src/livekitToolsExport.test.mjs
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { extractRealtimeTools } from '../scripts/export-realtime-tools.mjs';
+
+const root = new URL('..', import.meta.url).pathname;
+const viteConfigPath = join(root, 'vite.config.js');
+const exportedToolsPath = join(root, 'livekit-voice', 'tools.json');
+
+test('LiveKit tools export stays in sync with the Realtime tool literal', () => {
+  const source = readFileSync(viteConfigPath, 'utf8');
+  const tools = extractRealtimeTools(source);
+
+  assert.ok(Array.isArray(tools), 'tools must be an array');
+  assert.ok(tools.length >= 20, `expected the full voice tool registry, got ${tools.length}`);
+  assert.ok(tools.some((tool) => tool.name === 'fly_to_location'));
+  assert.ok(tools.some((tool) => tool.name === 'annotate_map'));
+
+  assert.ok(existsSync(exportedToolsPath), 'livekit-voice/tools.json must be generated and committed');
+  const exported = JSON.parse(readFileSync(exportedToolsPath, 'utf8'));
+  assert.deepEqual(exported, tools);
+});

--- a/src/voice/gevLiveKit.js
+++ b/src/voice/gevLiveKit.js
@@ -1,0 +1,171 @@
+const LIVEKIT_TOKEN_URL = '/api/livekit/token';
+const TOOL_TOPIC = 'gev.tools';
+
+function decodeLiveKitPayload(payload) {
+  if (typeof payload === 'string') return payload;
+  if (payload instanceof Uint8Array) return new TextDecoder().decode(payload);
+  if (payload?.buffer) return new TextDecoder().decode(new Uint8Array(payload.buffer));
+  return String(payload || '');
+}
+
+export class GevLiveKitController {
+  constructor({ runner, ui, radioLayer = null, dataManager = null }) {
+    this.runner = runner;
+    this.ui = ui;
+    this.radioLayer = radioLayer;
+    this.dataManager = dataManager;
+    this.room = null;
+    this.micTrack = null;
+    this.audioEls = new Set();
+    this.status = 'idle';
+    this.buttonHandler = null;
+    this.tierHandler = null;
+    this.annotationEventUnsubscribe = null;
+    this.startEpoch = 0;
+  }
+
+  isActive() {
+    return this.status !== 'idle' && this.status !== 'error';
+  }
+
+  bindPushToTalkShortcut() {
+    // Push-to-talk remains OpenAI-only for now. LiveKit mode is continuous mic.
+  }
+
+  syncCostUi() {
+    if (this.ui?.tierButton) this.ui.tierButton.hidden = true;
+    if (this.ui?.costSummary) this.ui.costSummary.textContent = 'Self-hosted voice';
+  }
+
+  toggleVoiceTier() {
+    this.syncCostUi();
+    return 'livekit';
+  }
+
+  setStatus(status, detail) {
+    this.status = status;
+    if (this.ui?.status) this.ui.status.textContent = detail || status;
+    if (this.ui?.button) {
+      this.ui.button.dataset.status = status;
+      this.ui.button.setAttribute('aria-pressed', this.isActive() ? 'true' : 'false');
+      this.ui.button.textContent = this.isActive() ? 'Stop voice' : 'Start voice';
+    }
+  }
+
+  reportError(source, error) {
+    const message = error?.message || String(error || 'unknown error');
+    console.error(`[GEV LiveKit] ${source}:`, error);
+    this.setStatus('error', `${source}: ${message}`);
+  }
+
+  async start() {
+    if (this.isActive()) return;
+    const epoch = ++this.startEpoch;
+    this.setStatus('connecting', 'Connecting LiveKit');
+
+    try {
+      if (!navigator.mediaDevices?.getUserMedia) {
+        throw new Error('Microphone support unavailable');
+      }
+      const [{ Room, RoomEvent, Track, createLocalAudioTrack }, tokenResponse] = await Promise.all([
+        import('livekit-client'),
+        fetch(LIVEKIT_TOKEN_URL, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({}),
+        }),
+      ]);
+      if (epoch !== this.startEpoch) return;
+      if (!tokenResponse.ok) {
+        const body = await tokenResponse.text().catch(() => '');
+        throw new Error(`LiveKit token failed: HTTP ${tokenResponse.status}${body ? ` ${body}` : ''}`);
+      }
+      const { url, token, room: roomName } = await tokenResponse.json();
+      const room = new Room({ adaptiveStream: true, dynacast: true });
+      this.room = room;
+
+      room.on(RoomEvent.DataReceived, (payload, participant, kind, topic) => {
+        if (topic !== TOOL_TOPIC) return;
+        this.handleToolPacket(payload).catch((error) => this.reportError('LiveKit tool bridge', error));
+      });
+      room.on(RoomEvent.TrackSubscribed, (track) => {
+        if (track.kind !== Track.Kind.Audio) return;
+        const el = track.attach();
+        el.autoplay = true;
+        this.audioEls.add(el);
+        document.body.appendChild(el);
+      });
+      room.on(RoomEvent.TrackUnsubscribed, (track) => {
+        for (const el of track.detach()) {
+          this.audioEls.delete(el);
+          el.remove();
+        }
+      });
+      room.on(RoomEvent.Disconnected, () => {
+        if (this.room === room) this.stop({ preserveStatus: this.status === 'error' });
+      });
+
+      await room.connect(url, token);
+      if (epoch !== this.startEpoch) return;
+      this.micTrack = await createLocalAudioTrack({ echoCancellation: true, noiseSuppression: true });
+      await room.localParticipant.publishTrack(this.micTrack, { name: 'microphone' });
+      this.setStatus('listening', `LiveKit voice on${roomName ? ` (${roomName})` : ''}`);
+    } catch (error) {
+      if (epoch === this.startEpoch) {
+        this.stop({ preserveStatus: true });
+        this.reportError('LiveKit connection', error);
+      }
+    }
+  }
+
+  async handleToolPacket(payload) {
+    const message = JSON.parse(decodeLiveKitPayload(payload));
+    if (message.type !== 'gev.tool_call') return;
+    const result = await this.runner(message.name, message.arguments || {}, {
+      signal: new AbortController().signal,
+      isCurrent: () => this.room?.state === 'connected',
+    });
+    await this.sendToolResult(message.call_id, result);
+  }
+
+  async sendToolResult(callId, result) {
+    if (!this.room || !callId) return;
+    const payload = new TextEncoder().encode(JSON.stringify({
+      type: 'gev.tool_result',
+      call_id: callId,
+      result,
+    }));
+    await this.room.localParticipant.publishData(payload, { reliable: true, topic: TOOL_TOPIC });
+  }
+
+  notifyMapEvent(payload) {
+    if (!this.room) return false;
+    const data = new TextEncoder().encode(JSON.stringify({ type: 'gev.map_event', payload }));
+    this.room.localParticipant.publishData(data, { reliable: true, topic: TOOL_TOPIC });
+    return true;
+  }
+
+  sendTextCommand(text) {
+    if (!this.room || !text) return false;
+    const data = new TextEncoder().encode(JSON.stringify({ type: 'gev.text_command', text }));
+    this.room.localParticipant.publishData(data, { reliable: true, topic: TOOL_TOPIC });
+    return true;
+  }
+
+  stop({ preserveStatus = false, removeUi = false } = {}) {
+    this.startEpoch += 1;
+    if (this.micTrack) {
+      this.micTrack.stop();
+      this.micTrack = null;
+    }
+    for (const el of this.audioEls) el.remove();
+    this.audioEls.clear();
+    if (this.room) {
+      const room = this.room;
+      this.room = null;
+      room.disconnect();
+    }
+    if (removeUi) this.ui?.root?.remove?.();
+    if (!preserveStatus) this.setStatus('idle', 'Voice off');
+  }
+}

--- a/src/voice/gevRealtime.js
+++ b/src/voice/gevRealtime.js
@@ -1,4 +1,5 @@
 import { createGevActionRunner, readLayerLifecycleSummary } from './gevActions.js';
+import { GevLiveKitController } from './gevLiveKit.js';
 import {
   DEFAULT_VOICE_TIER,
   VOICE_COST_LIMITS,
@@ -200,7 +201,10 @@ export function initGevVoiceCommands({ viewer, styleManager, dataManager, sceneD
   const runner = createGevActionRunner({ viewer, styleManager, dataManager, sceneDirector, annotations });
   const ui = createVoiceControl({ reset: true });
   const radioLayer = dataManager?.layers?.get('radio')?.module || null;
-  const controller = new GevRealtimeController({ runner, ui, radioLayer, dataManager });
+  const Controller = import.meta.env.VITE_VOICE_BACKEND === 'livekit'
+    ? GevLiveKitController
+    : GevRealtimeController;
+  const controller = new Controller({ runner, ui, radioLayer, dataManager });
   // Deferred annotation outlines finish AFTER their tool result returned. Feed the
   // final outcome (resolved / failed) into the conversation so the model can honestly
   // confirm — or correct — what it narrated about a boundary it never saw land.

--- a/style.css
+++ b/style.css
@@ -4386,6 +4386,7 @@ body.cockpit-mode #intel-hud .hud-right-edge { right: 22px; }
   align-items: flex-start;
   gap: 8px;
   pointer-events: none;
+  contain: layout paint;
   transition: top var(--transition-fast), bottom var(--transition-fast);
 }
 
@@ -4498,6 +4499,7 @@ body.cockpit-mode #intel-hud .hud-right-edge { right: 22px; }
   align-items: flex-end;
   gap: 8px;
   pointer-events: none;
+  contain: layout paint;
   transition: top var(--transition-fast), max-height var(--transition-fast);
 }
 #right-context-rail > #pp-toggles,
@@ -9151,6 +9153,179 @@ body.scene-playback-mode #first-run-launcher {
   to {
     -webkit-mask-image: linear-gradient(to bottom, #000 100%, transparent 100%);
     mask-image: linear-gradient(to bottom, #000 100%, transparent 100%);
+  }
+}
+
+/* ── First-run focus and clutter reduction ──────────────────────────────
+   The launcher is the only first-run task. While it is up, hide secondary
+   chrome instead of asking it to compete with every panel, chip, dock, and HUD
+   at once. This is distinct from ui-clean-view: it is temporary onboarding
+   focus, not a user-selected display mode. */
+body.first-run-focus #title-bar,
+body.first-run-focus #style-indicator,
+body.first-run-focus #top-center-actions,
+body.first-run-focus #global-loading-status,
+body.first-run-focus #traffic-sync-chip,
+body.first-run-focus #cctv-sync-chip,
+body.first-run-focus #left-panel-stack,
+body.first-run-focus #right-context-rail,
+body.first-run-focus #data-panel,
+body.first-run-focus #scene-panel,
+body.first-run-focus #cctv-panel,
+body.first-run-focus #global-context-panel,
+body.first-run-focus #radio-panel,
+body.first-run-focus #pp-toggles,
+body.first-run-focus #control-panel,
+body.first-run-focus #location-bar,
+body.first-run-focus #command-dock,
+body.first-run-focus #intel-hud,
+body.first-run-focus .gev-screen-whiteboard {
+  opacity: 0 !important;
+  visibility: hidden !important;
+  pointer-events: none !important;
+  transition: opacity 0.16s ease, visibility 0.16s ease;
+}
+
+body.first-run-focus #first-run-launcher {
+  z-index: 210;
+  box-shadow:
+    0 28px 72px rgba(0, 0, 0, 0.62),
+    0 0 0 1px rgba(120, 230, 255, 0.16) inset;
+}
+
+body.first-run-focus::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  z-index: 170;
+  pointer-events: none;
+  background:
+    radial-gradient(circle at 50% 42%, rgba(0, 212, 255, 0.09), transparent 34%),
+    linear-gradient(180deg, rgba(2, 5, 10, 0.24), rgba(2, 5, 10, 0.72));
+}
+
+body.first-run-focus #cesium-credits {
+  filter: saturate(0.85);
+}
+
+.first-run-arrow.material-symbols-outlined {
+  flex: 0 0 24px;
+  width: 24px;
+  height: 24px;
+  line-height: 24px;
+  overflow: visible;
+  text-align: center;
+}
+
+/* Bottom dock: collapsed trays should read as compact controls, not clipped
+   mini-panels. Expanded popovers keep the full labels. */
+#command-dock {
+  max-width: min(calc(100vw - 32px), 520px);
+  justify-content: center;
+  overflow: visible;
+}
+
+#command-dock .panel-collapsible.collapsed {
+  overflow: hidden;
+}
+
+#command-dock .panel-collapsible.collapsed :is(.location-toolbar-label, .panel-title, .pp-title) {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+}
+
+#gev-voice-control {
+  flex: 0 0 auto;
+}
+
+.gev-voice-heading {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* The sync chips are diagnostics. Keep them quiet unless a layer explicitly
+   makes them visible, and do not animate split-flaps while the onboarding card
+   owns the screen. */
+body.first-run-focus .gev-flap-cell,
+body.first-run-focus .gev-flap-cell::before,
+body.first-run-focus .gev-flap-cell::after {
+  animation: none !important;
+}
+
+/* Mobile = one drawer surface, not left+right rails plus a dock plus a modal. */
+@media (max-width: 620px) {
+  #title-bar {
+    max-width: min(62vw, 234px);
+    overflow: hidden;
+  }
+
+  #top-center-actions {
+    top: 78px;
+  }
+
+  #style-indicator {
+    right: 16px;
+    top: 22px;
+  }
+
+  #left-panel-stack,
+  #right-context-rail {
+    left: 16px;
+    right: 16px;
+    width: auto;
+    max-width: none;
+    align-items: stretch;
+  }
+
+  #left-panel-stack {
+    top: auto;
+    bottom: 5.75rem;
+    max-height: min(42vh, 340px);
+  }
+
+  #left-panel-stack:not(.layout-focus) > [data-panel-id].collapsed,
+  #right-context-rail:not(.layout-focus) > [data-panel-id].collapsed {
+    display: none;
+  }
+
+  #left-panel-stack > [data-panel-id]:not(.collapsed),
+  #right-context-rail > [data-panel-id]:not(.collapsed) {
+    width: 100% !important;
+    max-width: none;
+    max-height: inherit;
+    flex: 1 1 auto;
+  }
+
+  #command-dock {
+    width: auto;
+    left: 50%;
+    right: auto;
+    transform: translateX(-50%);
+    max-width: calc(100vw - 28px);
+    gap: 4px;
+    padding: 4px;
+  }
+
+  #command-dock .panel-collapsible.collapsed {
+    width: 52px !important;
+    min-width: 52px;
+  }
+
+  #command-dock .panel-collapsible.collapsed :is(.location-toolbar-label, .panel-title, .pp-title) {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+  }
+
+  #gev-voice-control {
+    transform: scale(0.92);
+    transform-origin: center bottom;
   }
 }
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -27,7 +27,7 @@
 
 import fs from 'node:fs';
 import { promises as fsp } from 'node:fs';
-import { createHash, randomUUID } from 'node:crypto';
+import { createHash, createHmac, randomUUID } from 'node:crypto';
 import path from 'node:path';
 import { Readable } from 'node:stream';
 import https from 'node:https';
@@ -4951,6 +4951,72 @@ function trackBackfillProxies() {
   };
 }
 
+function base64url(input) {
+  return Buffer.from(input).toString('base64url');
+}
+
+function signLiveKitToken({ apiKey, apiSecret, identity, room, ttlSeconds = 3600 }) {
+  const now = Math.floor(Date.now() / 1000);
+  const header = base64url(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
+  const payload = base64url(JSON.stringify({
+    iss: apiKey,
+    sub: identity,
+    nbf: now - 5,
+    iat: now,
+    exp: now + ttlSeconds,
+    video: {
+      room,
+      roomJoin: true,
+      canPublish: true,
+      canSubscribe: true,
+      canPublishData: true,
+    },
+  }));
+  const signature = createHmac('sha256', apiSecret).update(`${header}.${payload}`).digest('base64url');
+  return `${header}.${payload}.${signature}`;
+}
+
+/** Vite plugin: LiveKit browser token for self-hosted voice mode. */
+function liveKitTokenProxy() {
+  function install(middlewares) {
+    middlewares.use('/api/livekit/token', async (req, res) => {
+      if (req.method !== 'POST') {
+        res.statusCode = 405;
+        res.setHeader('Content-Type', 'application/json');
+        res.end(JSON.stringify({ error: 'Method not allowed' }));
+        return;
+      }
+      let body = '';
+      req.on('data', (chunk) => { body += chunk; });
+      req.on('end', () => {
+        try {
+          const parsed = body ? JSON.parse(body) : {};
+          const apiKey = process.env.LIVEKIT_API_KEY || 'devkey';
+          const apiSecret = process.env.LIVEKIT_API_SECRET || 'secret';
+          const publicUrl = process.env.LIVEKIT_PUBLIC_URL || process.env.LIVEKIT_URL || 'ws://localhost:7880';
+          const prefix = process.env.GEV_LIVEKIT_ROOM_PREFIX || 'gev-voice';
+          const suffix = String(parsed.room || randomUUID()).replace(/[^a-zA-Z0-9_-]/g, '').slice(0, 64) || randomUUID();
+          const room = suffix.startsWith(`${prefix}-`) ? suffix : `${prefix}-${suffix}`;
+          const identity = `browser-${randomUUID()}`;
+          const token = signLiveKitToken({ apiKey, apiSecret, identity, room });
+          res.statusCode = 200;
+          res.setHeader('Content-Type', 'application/json');
+          res.end(JSON.stringify({ url: publicUrl, token, room, identity }));
+        } catch (error) {
+          res.statusCode = 500;
+          res.setHeader('Content-Type', 'application/json');
+          res.end(JSON.stringify({ error: error?.message || String(error) }));
+        }
+      });
+    });
+  }
+  return {
+    name: 'gev-livekit-token-proxy',
+    configureServer(server) { install(server.middlewares); },
+    configurePreviewServer(server) { install(server.middlewares); },
+  };
+}
+
 /**
  * Vite plugin: OpenAI Realtime ephemeral client secret.
  *
@@ -7358,6 +7424,7 @@ export default defineConfig(({ mode }) => {
       adsbLolProxy(),
       aisLiveProxy(),
       trackBackfillProxies(),
+      liveKitTokenProxy(),
       openAiRealtimeProxy(),
       googlePlacesContextProxy(),
     ],
@@ -7373,6 +7440,7 @@ export default defineConfig(({ mode }) => {
     define: {
       'import.meta.env.GOOGLE_MAPS_API_KEY': JSON.stringify(env.GOOGLE_MAPS_API_KEY),
       'import.meta.env.CESIUM_ION_TOKEN': JSON.stringify(env.CESIUM_ION_TOKEN),
+      'import.meta.env.VITE_VOICE_BACKEND': JSON.stringify(env.VITE_VOICE_BACKEND || 'openai'),
     },
     build: {
       // The Cesium engine bundle is inherently large; raise the warning ceiling


### PR DESCRIPTION
## Summary
- Add Dockerfile + docker-compose.yml for the existing app/API proxy process.
- Add optional docker-compose.livekit.yml overlay for self-hosted voice via LiveKit.
- Add a LiveKit browser controller behind VITE_VOICE_BACKEND=livekit while keeping OpenAI Realtime as the default.
- Add LiveKit Agents Python worker, browser tool bridge, OpenAI-compatible local STT/LLM/TTS configuration, and docs.
- Export the existing GEV_REALTIME_TOOLS literal to livekit-voice/tools.json with a test that keeps it in sync.

## Verification
- npm run livekit:tools
- PYTHONPATH=. pytest -q livekit-voice/tests
- docker compose -f docker-compose.yml -f docker-compose.livekit.yml config
- npm run build
- docker compose -f docker-compose.yml -f docker-compose.livekit.yml build gods-eye-view livekit-agent
- Runtime smoke: started gods-eye-view + livekit, POST /api/livekit/token returned ws://localhost:7880 token + room.
- npm test: 2,588 passed; 0 failed. Two allocation microbenchmarks skipped because this host is Node 22 and the repo calibrates those gates for Node 24.

## Notes
- The LiveKit stack is opt-in. Default voice remains OpenAI Realtime.
- Model sidecars are configurable through livekit-voice/.env.example. Ollama defaults to qwen3:8b for 12GB GPU-class machines.

## UI cleanup update
- Added temporary `first-run-focus` mode so first launch is modal-exclusive instead of competing with rails, HUD, sync chips, dock, and diagnostics.
- Added mobile cleanup rules so collapsed rail siblings stay out of the first-run path and dock labels stop clipping on narrow screens.
- Added CSS containment to side rails to reduce layout/paint spillover during panel changes.
- Added first-run guardrail tests so future changes keep the quiet onboarding state.

Measured first launch at desktop/laptop/mobile:
- Before: 178-186 visible elements, 11 fixed overlays, 19-27 fixed-overlay overlaps, 19-22 clipping flags.
- After: 68 visible elements, 1 fixed overlay, 1 clipping flag (Cesium attribution container only).

Extra verification:
- `node --test src/creditAttribution.test.mjs src/firstRunExperience.test.mjs`
- `npm run build`
- `npm test` → 2,589 passed, 0 failed; 2 Node-24-only allocation gates skipped on this Node 22 host.

Screenshots were captured locally under `/home/hermes/workspace/gev-ui-review-final/screenshots/`.