### PR TITLE
fix: measure GBFS response cap in bytes, not string length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,10 @@ of current runtime behavior, see [`docs/CURRENT-STATE.md`](docs/CURRENT-STATE.md
 
 ### Security
 
+- GBFS proxy body-size cap now measures the response in bytes
+  (`Buffer.byteLength`) instead of JavaScript string length, so the
+  `GBFS_MAX_BODY_BYTES` limit holds for multi-byte payloads and cannot be
+  overrun by non-ASCII upstream responses.
 - Production transitive dependencies resolve to patched DOMPurify and
   protobufjs releases without changing the Cesium version or application APIs.
 - Production dependency audit reports no known advisories; remaining audit

--- a/vite.config.js
+++ b/vite.config.js
@@ -3323,7 +3323,7 @@ function gbfsProxy() {
             return;
           }
           const body = await upstream.text();
-          if (body.length > GBFS_MAX_BODY_BYTES) {
+          if (Buffer.byteLength(body, 'utf8') > GBFS_MAX_BODY_BYTES) {
             res.writeHead(502, { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' });
             res.end(JSON.stringify({ error: 'GBFS upstream response too large' }));
             return;


### PR DESCRIPTION
The GBFS proxy is supposed to cap upstream responses at 5 MB, but it was
checking body.length after decoding. That's a character count, not bytes, so
for multi-byte (non-ASCII) responses a body could go over the byte limit and
still pass the check.

Fix is one line: compare Buffer.byteLength(body, 'utf8') against the cap
instead. ASCII traffic under the cap behaves exactly as before; this only
tightens the edge case for multi-byte bodies.

Closes #32

### Testing
- npm run build and npm test are both green (2587 tests, 0 failures).
- npm run test:track: 99/100 on the pinned Chrome-for-Testing v145. The one
  failure (a ground-3d probe that expects 4 sampleHeight calls but sees 3)
  isn't from this change. It reproduces the same way on a clean main checkout
  and lives in the terrain/ground-snap code, which this PR doesn't touch.
  I've opened #44 for it.
- Checked the actual path by hand too: hitting /api/gbfs with Austin's
  station_information.json still returns 200 and valid JSON.
