### PR TITLE
fix: reject out-of-range coordinates in Google text-search proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,10 @@ of current runtime behavior, see [`docs/CURRENT-STATE.md`](docs/CURRENT-STATE.md
 
 ### Security
 
+- The `/api/google/text-search` proxy now rejects out-of-range coordinates
+  (latitude outside [-90, 90] or longitude outside [-180, 180]) with a 400
+  before contacting Google, so invalid input can no longer reach the
+  quota-bearing Places request.
 - Production transitive dependencies resolve to patched DOMPurify and
   protobufjs releases without changing the Cesium version or application APIs.
 - Production dependency audit reports no known advisories; remaining audit

--- a/vite.config.js
+++ b/vite.config.js
@@ -5426,6 +5426,12 @@ function googlePlacesContextProxy() {
         res.end(JSON.stringify({ error: 'q, lat and lon are required', places: [] }));
         return;
       }
+      if (latitude < -90 || latitude > 90 || longitude < -180 || longitude > 180) {
+        res.statusCode = 400;
+        res.setHeader('Content-Type', 'application/json');
+        res.end(JSON.stringify({ error: 'lat must be within [-90, 90] and lon within [-180, 180]', places: [] }));
+        return;
+      }
 
       try {
         const response = await fetch('https://places.googleapis.com/v1/places:searchText', {


### PR DESCRIPTION
/api/google/text-search validated that lat and lon were finite, but not that
they were actual coordinates. Anything finite got forwarded to Google Places,
so an out-of-range value spent quota on a request that could never return a
useful result.

This adds a bounds check right after the existing finite check: latitude has
to be within [-90, 90] and longitude within [-180, 180], otherwise the route
returns 400 before contacting Google. Valid coordinates are unaffected.

Scope note: issue #19 also mentions auth and rate limits for exposed use.
That is a broader concern shared across the other Google and OpenAI proxy
routes (#16, #17, #18), so I kept this PR to the coordinate-validation half,
which is the self-contained correctness fix. Using Refs rather than Closes so
the auth part can stay tracked.

Refs #19

### Testing
- npm run build and npm test are both green (2587 tests, 0 failures).
- npm run test:track: 99/100 on the pinned Chrome-for-Testing v145. The single
  failure is the pre-existing ground-3d probe tracked in #44, unrelated to this
  change and reproducible on a clean main.
- Verified by hand against a running dev server:
  - lat=999 and lon=-200 both return 400 with "lat must be within [-90, 90]
    and lon within [-180, 180]", with no upstream call made.
  - valid coordinates (lat=12.97, lon=77.59) pass the check and reach Google
    as before.
