### PR TITLE
Stop rebuilding the compass tape through innerHTML on every heading change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@ of current runtime behavior, see [`docs/CURRENT-STATE.md`](docs/CURRENT-STATE.md
   outages and wait for measured photoreal-surface evidence before a 3D model
   takes over from its billboard.
 - Cockpit altitude uses aviation MSL data rather than Cesium render height.
+- The cockpit compass tape builds its seven labels once and updates them in
+  place on a heading-bucket change, instead of re-parsing fresh HTML through
+  innerHTML every time.
 
 ### Security
 

--- a/src/ui.js
+++ b/src/ui.js
@@ -1444,15 +1444,26 @@ class CockpitViewController {
     );
     if (this.compassTape) {
       const divisions = compassDivisions(heading);
-      const signature = divisions.join(',');
-      if (signature !== this.lastCompassSignature) {
-        this.lastCompassSignature = signature;
+      if (!this.compassTapeSlots) {
+        // Slot positions never move, only which heading lands in each one, so
+        // the seven spans get built once and reused instead of going through
+        // innerHTML every time the tape advances.
         this.compassTape.innerHTML = divisions
           .map((division, index) => {
             const slot = index - 3;
-            return `<span class="${slot === 0 ? 'active' : ''}" style="--slot:${slot};--depth:${Math.abs(slot)}">${formatCompassDivision(division)}</span>`;
+            return `<span style="--slot:${slot};--depth:${Math.abs(slot)}"></span>`;
           })
           .join('');
+        this.compassTapeSlots = Array.from(this.compassTape.children);
+      }
+      const signature = divisions.join(',');
+      if (signature !== this.lastCompassSignature) {
+        this.lastCompassSignature = signature;
+        divisions.forEach((division, index) => {
+          const slotEl = this.compassTapeSlots[index];
+          slotEl.textContent = formatCompassDivision(division);
+          slotEl.classList.toggle('active', index === 3);
+        });
       }
     }
     if (this.clock) this.clock.textContent = new Date().toISOString().slice(11, 19) + 'Z';


### PR DESCRIPTION
Small one, from the render-performance list in #8 (item 4).

`src/ui.js` around the compass tape rebuilt all seven tick spans through
`innerHTML` on every heading-bucket change: new template string, parse,
throw away the old nodes. The `--slot`/`--depth` position each span sits at
never actually changes though, only which heading division ends up inside
it does.

This builds the seven spans once (lazily, on the first update) and caches
the references, then on a heading-bucket change just sets `textContent` and
toggles the `active` class on the cached nodes. Same signature-comparison
guard as before, so it still only touches the DOM when the heading crosses
into a new bucket, not every frame.

No visual or behavioral change. Positions, labels, and the active-tick
styling are identical, just fewer allocations and no re-parse on the
interaction-heavy path (camera turning).

Verified:
- `npm test`: same pass/fail set as a clean checkout of `main` (several
  suites fail with no API keys configured either way, unrelated to this).
- `npm run build`: clean.
- Confirmed nothing else in the codebase touches `#cockpit-compass-tape`'s
  children or relies on it being rebuilt (CSS keys entirely off the inline
  `--slot`/`--depth` custom properties and the `active` class, both still
  set exactly the same way).