### PR TITLE
fix: add an upstream connect timeout to the CCTV media proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,10 @@ of current runtime behavior, see [`docs/CURRENT-STATE.md`](docs/CURRENT-STATE.md
 
 ### Security
 
+- The CCTV media proxy now applies a bounded connect timeout to the upstream
+  fetch and returns a 504 when an upstream stalls, so a slow or hung source can
+  no longer hold a proxy request open indefinitely. The timer is cleared once
+  response headers arrive, so healthy live streams are unaffected.
 - Production transitive dependencies resolve to patched DOMPurify and
   protobufjs releases without changing the Cesium version or application APIs.
 - Production dependency audit reports no known advisories; remaining audit

--- a/vite.config.js
+++ b/vite.config.js
@@ -3451,6 +3451,10 @@ const CCTV_SOURCE_FETCH_TIMEOUT_MS = 15 * 1000;
  * client refresh cadence. A bounded miss can fall through to Street View or
  * the synthetic frame instead of leaving the browser preview pending. */
 export const CCTV_FRAME_FETCH_TIMEOUT_MS = 8 * 1000;
+/** Bounds how long the media proxy waits for an upstream to start responding.
+ * The timer is cleared once headers arrive, so a healthy live stream keeps
+ * flowing; only a stalled connect or a hung upstream is aborted (504). */
+const CCTV_MEDIA_FETCH_TIMEOUT_MS = 15 * 1000;
 /** @type {Array<object>} Cached merged + normalized CCTV source list. */
 let _cctvSourceCache = [];
 /** @type {number} Epoch-ms when the source cache was last refreshed. */
@@ -4562,9 +4566,17 @@ function cctvProxy() {
               const upstreamHeaders = { 'User-Agent': 'gods-eye-view-cctv-proxy/1.0' };
               const requestRange = req.headers?.range;
               if (requestRange) upstreamHeaders.Range = requestRange;
-              const upstream = await fetch(mediaUrl, {
-                headers: upstreamHeaders,
-              });
+              const controller = new AbortController();
+              const timeoutId = setTimeout(() => controller.abort(), CCTV_MEDIA_FETCH_TIMEOUT_MS);
+              let upstream;
+              try {
+                upstream = await fetch(mediaUrl, {
+                  headers: upstreamHeaders,
+                  signal: controller.signal,
+                });
+              } finally {
+                clearTimeout(timeoutId);
+              }
               const contentType = upstream.headers.get('content-type') || '';
               if (!upstream.ok) {
                 setHealth(cameraId, {
@@ -4599,14 +4611,15 @@ function cctvProxy() {
               });
               return;
             } catch (error) {
+              const timedOut = error?.name === 'AbortError' || error?.name === 'TimeoutError';
               setHealth(cameraId, {
                 status: 'degraded',
                 sourceKind: 'upstream',
                 label: source?.provider || 'Configured source',
-                message: error?.message || 'Media fetch failed',
+                message: timedOut ? 'Upstream timed out' : (error?.message || 'Media fetch failed'),
               });
-              res.writeHead(502, { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' });
-              res.end(JSON.stringify({ error: 'Media proxy failed' }));
+              res.writeHead(timedOut ? 504 : 502, { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' });
+              res.end(JSON.stringify({ error: timedOut ? 'Upstream media timeout' : 'Media proxy failed' }));
               return;
             }
           }


### PR DESCRIPTION
The CCTV media proxy (/api/cctv/media/:id) fetched the configured upstream
with no timeout. A slow or hung source could keep a proxy request open
indefinitely and tie up resources.

This wraps the upstream fetch in an AbortController with a bounded connect
timeout (15s) and returns a 504 when the upstream stalls, instead of a
generic 502. The important detail for streaming: the timer is cleared as soon
as response headers arrive, so a healthy live video stream is never cut off.
It follows the same pattern the GBFS proxy already uses in this file.

Scope note: this covers the connect timeout the issue calls out (the media
fetch had no AbortSignal). Idle and total-duration limits while a stream is in
flight are a separate concern tracked in #26.

Closes #25

### Testing
- npm run build and npm test are both green (2587 tests, 0 failures).
- npm run test:track: 99/100 on the pinned Chrome-for-Testing v145. The one
  failure is the pre-existing ground-3d probe tracked in #44, unrelated to
  this change and reproducible on a clean main.
- Verified both paths by hand against a running dev server:
  - A healthy camera returns 200 image/jpeg in well under a second, so normal
    proxying is unaffected.
  - A source pointed at a deliberately hung upstream now returns
    504 "Upstream media timeout" right at the 15s bound, instead of hanging.
