### PR TITLE
feat: add Docker image and GHCR publishing

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,33 @@
+# Git
+.git
+.gitignore
+.github
+
+# Local environment/secrets
+.env
+.env.*
+!.env.example
+
+# Dependencies and local caches
+node_modules
+.npm
+.pnpm-store
+.yarn
+.yarn-cache
+
+# Build/test output
+dist
+coverage
+.vite
+.gev-cache
+.gev-logs
+
+# OS/editor files
+.DS_Store
+Thumbs.db
+.vscode
+.idea
+
+# Logs
+*.log
+npm-debug.log*

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,66 @@
+name: Publish Docker image
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "v*"
+  pull_request:
+    paths:
+      - "Dockerfile"
+      - ".dockerignore"
+      - ".github/workflows/docker-publish.yml"
+      - "package.json"
+      - "package-lock.json"
+      - "vite.config.*"
+      - "src/**"
+      - "public/**"
+      - "index.html"
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=ref,event=tag
+            type=sha
+
+      - name: Build Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,8 @@ COPY . .
 
 ENV NODE_ENV=production
 ENV HOST=0.0.0.0
-ENV PORT=5173
+ENV PORT=4173
 
-EXPOSE 5173
+EXPOSE 4173
 
 CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0", "--port", "5173"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+# God's Eye View
+# Issue #48: pre-built Docker image for easier local/self-hosted deployment.
+#
+#
+# Node 24.14.x is required by package.json.
+
+FROM node:24.14.0-bookworm-slim
+
+WORKDIR /app
+
+# Install dependencies first so Docker can reuse this layer when source files change.
+COPY package.json package-lock.json ./
+RUN npm ci
+
+# Copy application source. .
+COPY . .
+
+ENV NODE_ENV=production
+ENV HOST=0.0.0.0
+ENV PORT=5173
+
+EXPOSE 5173
+
+CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0", "--port", "5173"]

--- a/README.md
+++ b/README.md
@@ -68,6 +68,33 @@ Requires Node.js 24.14.x or 26.x (enforced by `package.json`).
 npm install
 npm run dev -- --host localhost --port 4173
 ```
+OR
+
+### 🐳 Run with Docker
+
+A pre-built image which can be run from GitHub Container Registry.
+
+run:
+
+```bash
+docker run -d \
+  --name gods-eye-view \
+  -p 4173:4173 \
+  --env-file .env \
+  ghcr.io/bilawalsidhu/gods-eye-view:latest
+```
+### Build locally
+
+To test the container locally from the repository:
+
+```bash
+docker build -t gods-eye-view:local .
+docker run --rm -d \
+  --name gods-eye-view \
+  -p 4173:4173 \
+  --env-file .env \
+  gods-eye-view:local
+```
 
 3. Open **`http://localhost:4173`**. Cold start settles in under two seconds on a recent laptop (median 1.86 s in a point-in-time M5/Chrome capture — [docs/PERFORMANCE.md](docs/PERFORMANCE.md); a comparison baseline, not a hardware requirement). A first-run card offers to stage a mission for you — **Live Contacts**, **Space Missions**, **Environmental** — or leaves you to explore manually.
 
@@ -77,6 +104,11 @@ The dev server binds to **localhost** — your keys stay on your machine. Sharin
 
 **macOS shortcut:** `./scripts/dev-fresh.sh` clears the Vite cache and pulls your keys straight from the Keychain.
 
+**Security:** never bake `.env` or private API keys into the Docker image.
+`OPENAI_API_KEY`, `AISSTREAM_API_KEY`, OpenSky credentials, and similar
+server-side credentials remain runtime environment variables. The Google Maps
+key and Cesium ion token are intentionally client-exposed by the application
+and should be restricted according to [SECURITY.md](SECURITY.md).
 ---
 
 ## 🕐 The First Five Minutes


### PR DESCRIPTION
## Summary

Implements the Docker/GHCR portion of Issue #48.

### Changes

- Add Dockerfile using Node.js 24.14.x
- Add `.dockerignore`
- Add GitHub Actions workflow for GHCR publishing
- Add Docker usage and local build instructions to README

### Docker usage

```bash
docker run -d \
  --name gods-eye-view \
  -p 4173:4173 \
  --env-file .env \
  ghcr.io/bilawalsidhu/gods-eye-view:latest
```
Resolves #48