### PR TITLE
Make the Google Maps key optional

### DIFF
--- a/src/locations.js
+++ b/src/locations.js
@@ -341,6 +341,95 @@ export function findPoiByName(query) {
 /** Distinguishes an authority veto from a genuine not-found result. */
 export const CANCELLED_SEARCH = Object.freeze({ cancelled: true });
 
+// Nominatim place classes mapped onto the Google geocode types that
+// geocodeNavigationMode() already understands, so the keyless path reuses the
+// same framing policy rather than inventing a second one.
+const NOMINATIM_TYPE_MAP = {
+  country: ['country'],
+  state: ['administrative_area_level_1'],
+  region: ['administrative_area_level_1'],
+  province: ['administrative_area_level_1'],
+  county: ['administrative_area_level_2'],
+  city: ['locality'],
+  town: ['locality'],
+  village: ['locality'],
+  municipality: ['locality'],
+  suburb: ['sublocality'],
+  neighbourhood: ['neighborhood'],
+  postcode: ['postal_code'],
+  road: ['route'],
+  park: ['park'],
+  aerodrome: ['airport'],
+  stadium: ['stadium'],
+  university: ['university'],
+  peak: ['natural_feature'],
+  water: ['natural_feature'],
+  bay: ['natural_feature'],
+};
+
+/**
+ * Keyless geocode via OpenStreetMap Nominatim, used when no Google Maps key is
+ * configured. Covers the common case — places, streets, landmarks — but has no
+ * viewport bias and no Places recovery, so ambiguous names ("Sixth Street") may
+ * land in the wrong city. Nominatim asks for <=1 req/sec; search is user-driven
+ * and well under that.
+ */
+async function searchAndFlyToKeyless(viewer, query, options = {}) {
+  const beforeFly = typeof options.beforeFly === 'function' ? options.beforeFly : null;
+  const mayFly = () => beforeFly === null || beforeFly() !== false;
+
+  const url = `https://nominatim.openstreetmap.org/search?format=jsonv2&limit=1&q=${encodeURIComponent(query)}`;
+  let hit = null;
+  try {
+    const response = await fetch(url, { headers: { Accept: 'application/json' } });
+    if (!response.ok) return null;
+    hit = (await response.json())?.[0] || null;
+  } catch (error) {
+    console.warn('[Geocode] Nominatim lookup failed:', error);
+    return null;
+  }
+  if (!hit) return null;
+
+  const lat = Number(hit.lat);
+  const lng = Number(hit.lon);
+  if (!Number.isFinite(lat) || !Number.isFinite(lng)) return null;
+
+  const label = hit.display_name || query;
+  const types = NOMINATIM_TYPE_MAP[hit.addresstype] || NOMINATIM_TYPE_MAP[hit.type] || [];
+  const navigationMode = geocodeNavigationMode(types);
+  const duration = finitePositive(options.duration) || 3.0;
+  const requestedRange = finitePositive(options.range);
+
+  // boundingbox arrives as [south, north, west, east] strings.
+  const box = Array.isArray(hit.boundingbox) ? hit.boundingbox.map(Number) : null;
+  const viewport = box && box.every(Number.isFinite)
+    ? { southwest: { lat: box[0], lng: box[2] }, northeast: { lat: box[1], lng: box[3] } }
+    : null;
+
+  if (viewport && !requestedRange && !options.forceClose
+      && (shouldFrameGeocodeViewport(navigationMode) || options.viewMode === 'overview')) {
+    const flight = flyToViewportBounds(viewer, viewport, {
+      duration,
+      navigationMode,
+      beforeFly: mayFly,
+      onStart: options.onStart,
+      onComplete: options.onComplete,
+      onCancel: options.onCancel,
+    });
+    if (flight) return { label, navigationMode };
+  }
+
+  if (!mayFly()) return CANCELLED_SEARCH;
+  flyToLandmark(viewer, lat, lng, {
+    range: requestedRange,
+    duration,
+    onStart: options.onStart,
+    onComplete: options.onComplete,
+    onCancel: options.onCancel,
+  });
+  return { label, navigationMode };
+}
+
 /**
  * Geocode a place name using Google Geocoding API, then fly there at a scale
  * appropriate to the request. Countries and cities use their viewport by
@@ -348,7 +437,7 @@ export const CANCELLED_SEARCH = Object.freeze({ cancelled: true });
  */
 export async function searchAndFlyTo(viewer, query, options = {}) {
   const apiKey = window.__GOOGLE_MAPS_API_KEY__ || import.meta.env.GOOGLE_MAPS_API_KEY;
-  if (!apiKey) throw new Error('No Google Maps API key available for geocoding');
+  if (!apiKey) return searchAndFlyToKeyless(viewer, query, options);
 
   const beforeFly = typeof options.beforeFly === 'function' ? options.beforeFly : null;
   const mayFly = () => beforeFly === null || beforeFly() !== false;

--- a/src/main.js
+++ b/src/main.js
@@ -79,15 +79,18 @@ async function init() {
       Cesium.Ion.defaultAccessToken = cesiumToken;
     }
 
-    // Set Google Maps API key for 3D Tiles
+    // Set Google Maps API key for 3D Tiles. Optional: without it the app runs
+    // on the ion/OSM globe stacks instead of photorealistic 3D — every data
+    // layer is unaffected, and geocoding falls back to Nominatim.
     const googleApiKey = import.meta.env.GOOGLE_MAPS_API_KEY;
-    if (!googleApiKey) {
-      throw new Error('GOOGLE_MAPS_API_KEY not found. Set it as an environment variable.');
-    }
-    Cesium.GoogleMaps.defaultApiKey = googleApiKey;
+    if (googleApiKey) {
+      Cesium.GoogleMaps.defaultApiKey = googleApiKey;
 
-    // Expose API key globally for geocoding in locations.js
-    window.__GOOGLE_MAPS_API_KEY__ = googleApiKey;
+      // Expose API key globally for geocoding in locations.js
+      window.__GOOGLE_MAPS_API_KEY__ = googleApiKey;
+    } else {
+      console.warn('[Init] GOOGLE_MAPS_API_KEY not set — photorealistic 3D disabled, using globe imagery.');
+    }
 
     // Create the Cesium viewer with minimal chrome
     const viewer = new Cesium.Viewer('cesiumContainer', {
@@ -153,31 +156,43 @@ async function init() {
     viewer.scene.skyAtmosphere.saturationShift = -0.12;
     viewer.scene.skyAtmosphere.brightnessShift = -0.08;
 
-    loaderStatus.textContent = 'Loading Google 3D Tiles...';
     let tileset = null;
-    try {
-      // Load Google Photorealistic 3D Tiles
-      tileset = await Cesium.createGooglePhotorealistic3DTileset({
-        onlyUsingWithGoogleGeocoder: true,
-      });
-      viewer.scene.primitives.add(tileset);
-      // NOTE: Cesium World Terrain intentionally disabled — conflicts with Google 3D Tiles at high zoom.
-      // Google Photorealistic 3D Tiles provide their own terrain/elevation.
-      viewer.scene.globe.show = false;
-    } catch (tileError) {
-      console.warn('[Init] Google 3D Tiles unavailable, falling back to Cesium globe:', tileError);
-      const tileErrorDetail = describeError(tileError);
-      loaderStatus.textContent = `Google 3D Tiles unavailable (${tileErrorDetail}). Continuing in fallback mode...`;
-      // Keep Cesium globe visible as fallback instead of aborting the app.
+    if (!googleApiKey) {
+      // No Google key: skip the photoreal tileset entirely and keep the Cesium
+      // globe visible. MapStackController already treats a null tileset as the
+      // ion/OSM regime, so nothing downstream needs to know.
+      loaderStatus.textContent = 'No Google key — using globe imagery...';
       viewer.scene.globe.show = true;
+    } else {
+      loaderStatus.textContent = 'Loading Google 3D Tiles...';
+      try {
+        // Load Google Photorealistic 3D Tiles
+        tileset = await Cesium.createGooglePhotorealistic3DTileset({
+          onlyUsingWithGoogleGeocoder: true,
+        });
+        viewer.scene.primitives.add(tileset);
+        // NOTE: Cesium World Terrain intentionally disabled — conflicts with Google 3D Tiles at high zoom.
+        // Google Photorealistic 3D Tiles provide their own terrain/elevation.
+        viewer.scene.globe.show = false;
+      } catch (tileError) {
+        console.warn('[Init] Google 3D Tiles unavailable, falling back to Cesium globe:', tileError);
+        const tileErrorDetail = describeError(tileError);
+        loaderStatus.textContent = `Google 3D Tiles unavailable (${tileErrorDetail}). Continuing in fallback mode...`;
+        // Keep Cesium globe visible as fallback instead of aborting the app.
+        viewer.scene.globe.show = true;
+      }
     }
 
     loaderStatus.textContent = 'Initializing systems...';
 
+    // Photoreal when Google is configured; otherwise prefer ion's Bing aerial
+    // (real imagery + world terrain) and fall back to keyless OSM tiles.
+    const initialMapStack = tileset ? 'photoreal' : (cesiumToken ? 'bing-aerial' : 'osm');
+
     const mapStackController = new MapStackController(viewer, {
       googleTileset: tileset,
       cesiumToken,
-      initialStack: tileset ? 'photoreal' : 'osm',
+      initialStack: initialMapStack,
       // Task 5 (height-datum fix): rebroadcast stack changes as a window
       // CustomEvent so data layers (CCTV per-regime ground resolution) can
       // react without coupling MapStackController to layer modules. Fires on
@@ -188,7 +203,7 @@ async function init() {
       },
       onError: (message) => console.warn('[MapStack]', message),
     });
-    await mapStackController.setStack(tileset ? 'photoreal' : 'osm', { silent: true });
+    await mapStackController.setStack(initialMapStack, { silent: true });
 
     // Initialize the style manager (post-processing, HUD, locations, share links)
     const styleManager = new StyleManager(viewer, { mapStackController });


### PR DESCRIPTION
### The problem

`src/main.js` throws when `GOOGLE_MAPS_API_KEY` is absent, before the viewer is constructed. The app therefore cannot start at all without a billing-enabled Google Cloud account.

That is a hard gate in front of everything that needs no credentials. Ten of the thirteen layers are keyless — flights, military ADS-B, satellites, earthquakes, CCTV, radio, bikeshare, launches, mapped installations, and every bundled dataset — and none of them are reachable without first setting up Google billing.

I hit this as a new user: enabling Map Tiles requires a billing account, and the signup flow is easy to get stuck in. The README's promise that most of the globe is 🟢 isn't reachable until that's resolved.

### The change

`MapStackController` already treats a null Google tileset as the ion/OSM regime, so very little needed to move.

- **`main.js`** — the throw becomes a warning. With no key the photoreal tileset fetch is skipped and the Cesium globe stays visible.
- **`main.js`** — the initial map stack now resolves `photoreal` → `bing-aerial` → `osm` by what's actually configured. Previously `'osm'` was hardcoded whenever the Google tileset was absent, so an available Cesium ion token was ignored and users with ion got flat OSM tiles instead of Bing aerial.
- **`locations.js`** — `searchAndFlyTo` threw `No Google Maps API key available for geocoding`, breaking search entirely. It now falls back to OpenStreetMap Nominatim, reusing the existing `geocodeNavigationMode` / `flyToViewportBounds` / `flyToLandmark` framing rather than introducing a second policy.

**With a key present, every path is byte-for-byte unchanged.** The fallbacks are reached only when the key is absent.

### Limitations, stated honestly

The keyless geocoder has no viewport bias and no Places-near-view recovery, so ambiguous names ("Sixth Street") can land in the wrong city. That's documented in the JSDoc rather than papered over. Nominatim place classes are mapped onto the Google geocode types `geocodeNavigationMode` already understands, with a two-step lookup on `addresstype` then `type` — Nominatim reports airports as `addresstype: aeroway`, `type: aerodrome`, and only the latter maps cleanly.

Users without Google lose photorealistic 3D building meshes. Everything data-driven — tracking, orbits, trails, detection, cockpit — is unaffected.

### Testing

- `npm test` — **2601 passing, 0 failing**, on this branch in isolation.
- Verified in-browser keyless: app boots, map stack reports `Aerial` with an ion token and `OSM` without one, no console errors, all live layers populate (OpenSky, adsb.lol, AISStream, FIRMS, TomTom).
- Verified with a Google key present: photoreal path unchanged.