### PR TITLE
fix: make Windows Precision Touchpad pinch-zoom the globe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@ of current runtime behavior, see [`docs/CURRENT-STATE.md`](docs/CURRENT-STATE.md
 
 ### Fixed
 
+- Windows laptop touchpads can pinch-zoom and two-finger-scroll the globe.
+  Precision Touchpad pinch arrives as Ctrl+wheel, which Cesium recorded but
+  never bound to zoom; two-finger motion no longer tilts on a fine pointer.
+  Pinch and two-finger zoom now share a 0.002 height scale (~2.5× Cesium
+  wheel) so the gestures feel snappier. Click-drag orbit and Ctrl+drag tilt
+  are unchanged.
 - A missing optional FIRMS key no longer turns the complete Environmental
   mission into `LOAD FAILED`. The FIRMS row still reports `KEY REQUIRED`, while
   earthquakes continue to load. Real lifecycle and fetch failures retain

--- a/docs/CURRENT-STATE.md
+++ b/docs/CURRENT-STATE.md
@@ -2036,7 +2036,13 @@ silently demoting every later lookup for the session.
   not claim that lane or partially change controls.
   Direct globe pointer and wheel gestures supersede the delayed shared camera
   and selected-subject Follow without aborting unrelated layer visibility or
-  display-option restoration.
+  display-option restoration. On a fine pointer (typical laptop),
+  `installTouchpadCamera` (`src/cameraTouchpad.js`) maps Windows Precision
+  Touchpad pinch (Ctrl/Meta+wheel) and continuous two-finger scroll to zoom
+  at `0.002 × altitude × wheel Δ`, and drops unmodified PINCH from tilt so
+  two-finger motion does not orbit. Discrete mouse-wheel notches and
+  touch-screen pinch-zoom stay on Cesium; click-drag orbit and Ctrl+drag
+  tilt are unchanged.
 - The initial restore has one terminal promise spanning the camera flight,
   visual/map/panel callback work, every production layer result, and the
   destination-scoped selected-subject Follow result. Hash writes remain

--- a/src/camera.js
+++ b/src/camera.js
@@ -1,5 +1,7 @@
 import * as Cesium from 'cesium';
 
+export { installTouchpadCamera } from './cameraTouchpad.js';
+
 /**
  * Camera presets for notable locations.
  * Phase 1 default: fly to Austin, TX on load.

--- a/src/cameraTouchpad.js
+++ b/src/cameraTouchpad.js
@@ -1,0 +1,190 @@
+import * as Cesium from 'cesium';
+
+/**
+ * Windows Precision Touchpad pinch arrives as Ctrl+wheel. Cesium records
+ * WHEEL+CTRL but only zooms on unmodified WHEEL, so pinch does nothing
+ * (and two-finger scroll can tilt if the pad also emits touch). This module
+ * binds modifier-wheel to zoom and keeps laptop two-finger motion from
+ * tilting, without changing mouse wheel or touch-screen pinch-zoom.
+ */
+
+const INSTALLED = new WeakMap();
+
+const WHEEL_ZOOM_MODIFIERS = [
+  Cesium.KeyboardEventModifier.CTRL,
+  Cesium.KeyboardEventModifier.SHIFT,
+];
+
+const DELTA_LINE_PX = 16;
+const DELTA_PAGE_PX = 120;
+
+/**
+ * Per-pixel, height-scaled zoom for touchpad pinch (Ctrl+wheel) and
+ * two-finger scroll. Cesium's own wheel path is about
+ * `5 * 7.5°/px / canvasHeight` (~0.00073 on a 900px view). 0.002 is ~2.5–2.7×
+ * that — snappy without a short flick jumping across the globe.
+ * Discrete mouse notches (≥80px or line/page mode) stay on Cesium.
+ */
+export const TOUCHPAD_WHEEL_ZOOM_SCALE = 0.002;
+
+/** Pixel deltas this large are treated as a mouse-wheel notch, not a touchpad. */
+const MOUSE_WHEEL_NOTCH_PX = 80;
+
+/** @param {Pick<WheelEvent, 'deltaMode' | 'deltaX' | 'deltaY'>} event */
+export function wheelDeltaPixels(event) {
+  const mode = Number(event?.deltaMode) || 0;
+  const scale = mode === 1 ? DELTA_LINE_PX : mode === 2 ? DELTA_PAGE_PX : 1;
+  return {
+    x: Number(event?.deltaX) * scale || 0,
+    y: Number(event?.deltaY) * scale || 0,
+  };
+}
+
+/**
+ * Zoom uses the dominant axis so a mostly-horizontal two-finger scroll still
+ * zooms instead of disappearing into Cesium's deltaY-only wheel handler.
+ * @param {Pick<WheelEvent, 'deltaMode' | 'deltaX' | 'deltaY'>} event
+ */
+export function wheelZoomDeltaPixels(event) {
+  const { x, y } = wheelDeltaPixels(event);
+  return Math.abs(x) > Math.abs(y) ? x : y;
+}
+
+/** @param {Pick<WheelEvent, 'ctrlKey' | 'metaKey'>} event */
+export function isTouchpadPinchWheel(event) {
+  return Boolean(event?.ctrlKey || event?.metaKey);
+}
+
+export function isHorizontalWheel(event) {
+  const { x, y } = wheelDeltaPixels(event);
+  return Math.abs(x) > Math.abs(y);
+}
+
+/**
+ * Precision Touchpad pinch (Ctrl/Meta+wheel) or continuous two-finger
+ * pixel-scroll. Leaves discrete mouse-wheel notches for Cesium.
+ * @param {Pick<WheelEvent, 'ctrlKey' | 'metaKey' | 'deltaMode' | 'deltaX' | 'deltaY'>} event
+ */
+export function isTouchpadZoomWheel(event) {
+  if (isTouchpadPinchWheel(event)) return true;
+  const mode = Number(event?.deltaMode) || 0;
+  if (mode !== 0) return false;
+  const delta = Math.abs(wheelZoomDeltaPixels(event));
+  return delta > 0 && delta < MOUSE_WHEEL_NOTCH_PX;
+}
+
+/**
+ * Append Ctrl/Shift+wheel zoom bindings. Cesium already listens for those
+ * modifier wheels (and preventDefaults them) but never consumes them.
+ * @param {Array|object|undefined} eventTypes
+ */
+export function withModifierWheelZoomTypes(eventTypes) {
+  const list = normalizeEventTypes(eventTypes);
+  for (const modifier of WHEEL_ZOOM_MODIFIERS) {
+    const exists = list.some((entry) => (
+      entry
+      && typeof entry === 'object'
+      && entry.eventType === Cesium.CameraEventType.WHEEL
+      && entry.modifier === modifier
+    ));
+    if (!exists) {
+      list.push({
+        eventType: Cesium.CameraEventType.WHEEL,
+        modifier,
+      });
+    }
+  }
+  return list;
+}
+
+/**
+ * Drop unmodified PINCH from tilt so a laptop touchpad that also emits
+ * touch events cannot tilt/orbit on two-finger scroll. Pinch stays on zoom.
+ * @param {Array|object|undefined} eventTypes
+ */
+export function withoutUnmodifiedPinchTilt(eventTypes) {
+  return normalizeEventTypes(eventTypes).filter((entry) => !isUnmodifiedPinch(entry));
+}
+
+/** @param {(query: string) => { matches: boolean }} [matchMedia] */
+export function prefersFinePointer(matchMedia = globalThis.matchMedia) {
+  if (typeof matchMedia !== 'function') return true;
+  try {
+    return Boolean(matchMedia.call(globalThis, '(hover: hover) and (pointer: fine)')?.matches);
+  } catch {
+    return true;
+  }
+}
+
+export function zoomAmountFromWheelPixels(pixels, heightMeters) {
+  const delta = Number(pixels);
+  const height = Number(heightMeters);
+  if (!Number.isFinite(delta) || delta === 0) return 0;
+  const altitude = Number.isFinite(height) && height > 0 ? height : 1000;
+  return altitude * TOUCHPAD_WHEEL_ZOOM_SCALE * delta;
+}
+
+/**
+ * Wire Precision Touchpad pinch / two-finger scroll. Idempotent per viewer.
+ * @param {{ scene?: { canvas?: EventTarget, screenSpaceCameraController?: object }, camera?: { zoomIn?: Function, positionCartographic?: { height?: number } } }} viewer
+ */
+export function installTouchpadCamera(viewer) {
+  const scene = viewer?.scene;
+  const controller = scene?.screenSpaceCameraController;
+  const canvas = scene?.canvas;
+  if (!controller || !canvas?.addEventListener) return () => {};
+
+  const existing = INSTALLED.get(viewer);
+  if (existing) return existing;
+
+  controller.zoomEventTypes = withModifierWheelZoomTypes(controller.zoomEventTypes);
+  if (prefersFinePointer()) {
+    controller.tiltEventTypes = withoutUnmodifiedPinchTilt(controller.tiltEventTypes);
+  }
+
+  const onWheel = (event) => {
+    if (!controller.enableInputs || controller.enableZoom === false) return;
+    // Own pinch and two-finger zoom so they share TOUCHPAD_WHEEL_ZOOM_SCALE.
+    // Cesium's WHEEL listener is bubble-phase; stopImmediatePropagation here
+    // (capture) keeps it from also applying its slower mapping.
+    if (!isTouchpadZoomWheel(event)) return;
+    const amount = zoomAmountFromWheelPixels(
+      wheelZoomDeltaPixels(event),
+      viewer.camera?.positionCartographic?.height,
+    );
+    if (isTouchpadPinchWheel(event) || amount) {
+      // Browser page-zoom is Ctrl+wheel. Prevent in capture so Chrome cannot
+      // zoom the UI if Cesium's bubble listener is late or missing.
+      event.preventDefault();
+    }
+    if (!amount) return;
+    event.stopImmediatePropagation?.();
+    viewer.camera?.zoomIn?.(-amount);
+    viewer.scene?.requestRender?.();
+  };
+
+  canvas.addEventListener('wheel', onWheel, { capture: true, passive: false });
+
+  const dispose = () => {
+    canvas.removeEventListener('wheel', onWheel, { capture: true });
+    INSTALLED.delete(viewer);
+  };
+  INSTALLED.set(viewer, dispose);
+  return dispose;
+}
+
+function normalizeEventTypes(eventTypes) {
+  if (Array.isArray(eventTypes)) return [...eventTypes];
+  if (eventTypes == null) return [];
+  return [eventTypes];
+}
+
+function isUnmodifiedPinch(entry) {
+  if (entry === Cesium.CameraEventType.PINCH) return true;
+  return Boolean(
+    entry
+    && typeof entry === 'object'
+    && entry.eventType === Cesium.CameraEventType.PINCH
+    && entry.modifier == null,
+  );
+}

--- a/src/cameraTouchpad.test.mjs
+++ b/src/cameraTouchpad.test.mjs
@@ -1,0 +1,224 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import * as Cesium from 'cesium';
+import {
+  installTouchpadCamera,
+  isHorizontalWheel,
+  isTouchpadPinchWheel,
+  isTouchpadZoomWheel,
+  prefersFinePointer,
+  TOUCHPAD_WHEEL_ZOOM_SCALE,
+  wheelDeltaPixels,
+  wheelZoomDeltaPixels,
+  withModifierWheelZoomTypes,
+  withoutUnmodifiedPinchTilt,
+  zoomAmountFromWheelPixels,
+} from './cameraTouchpad.js';
+
+test('wheel deltas honor pixel, line, and page units', () => {
+  assert.deepEqual(wheelDeltaPixels({ deltaX: 3, deltaY: -8, deltaMode: 0 }), { x: 3, y: -8 });
+  assert.deepEqual(wheelDeltaPixels({ deltaX: 0, deltaY: 2, deltaMode: 1 }), { x: 0, y: 32 });
+  assert.deepEqual(wheelDeltaPixels({ deltaX: 1, deltaY: -1, deltaMode: 2 }), { x: 120, y: -120 });
+});
+
+test('zoom uses the dominant axis so horizontal two-finger scroll is not dropped', () => {
+  assert.equal(wheelZoomDeltaPixels({ deltaX: 0, deltaY: 40, deltaMode: 0 }), 40);
+  assert.equal(wheelZoomDeltaPixels({ deltaX: -24, deltaY: 2, deltaMode: 0 }), -24);
+  assert.equal(isHorizontalWheel({ deltaX: -24, deltaY: 2, deltaMode: 0 }), true);
+  assert.equal(isHorizontalWheel({ deltaX: 1, deltaY: -20, deltaMode: 0 }), false);
+});
+
+test('Windows Precision Touchpad pinch is Ctrl+wheel (meta counts too)', () => {
+  assert.equal(isTouchpadPinchWheel({ ctrlKey: true, metaKey: false }), true);
+  assert.equal(isTouchpadPinchWheel({ ctrlKey: false, metaKey: true }), true);
+  assert.equal(isTouchpadPinchWheel({ ctrlKey: false, metaKey: false }), false);
+});
+
+test('modifier-wheel zoom types are appended once and leave mouse wheel / pinch intact', () => {
+  const types = withModifierWheelZoomTypes([
+    Cesium.CameraEventType.RIGHT_DRAG,
+    Cesium.CameraEventType.WHEEL,
+    Cesium.CameraEventType.PINCH,
+  ]);
+  assert.deepEqual(types.slice(0, 3), [
+    Cesium.CameraEventType.RIGHT_DRAG,
+    Cesium.CameraEventType.WHEEL,
+    Cesium.CameraEventType.PINCH,
+  ]);
+  assert.deepEqual(types[3], {
+    eventType: Cesium.CameraEventType.WHEEL,
+    modifier: Cesium.KeyboardEventModifier.CTRL,
+  });
+  assert.deepEqual(types[4], {
+    eventType: Cesium.CameraEventType.WHEEL,
+    modifier: Cesium.KeyboardEventModifier.SHIFT,
+  });
+  assert.equal(withModifierWheelZoomTypes(types).length, types.length);
+});
+
+test('laptop tilt bindings drop unmodified pinch and keep Ctrl-drag tilt', () => {
+  const filtered = withoutUnmodifiedPinchTilt([
+    Cesium.CameraEventType.MIDDLE_DRAG,
+    Cesium.CameraEventType.PINCH,
+    {
+      eventType: Cesium.CameraEventType.LEFT_DRAG,
+      modifier: Cesium.KeyboardEventModifier.CTRL,
+    },
+    {
+      eventType: Cesium.CameraEventType.PINCH,
+      modifier: Cesium.KeyboardEventModifier.SHIFT,
+    },
+  ]);
+  assert.deepEqual(filtered, [
+    Cesium.CameraEventType.MIDDLE_DRAG,
+    {
+      eventType: Cesium.CameraEventType.LEFT_DRAG,
+      modifier: Cesium.KeyboardEventModifier.CTRL,
+    },
+    {
+      eventType: Cesium.CameraEventType.PINCH,
+      modifier: Cesium.KeyboardEventModifier.SHIFT,
+    },
+  ]);
+});
+
+test('fine-pointer detection treats a phone as coarse and a laptop as fine', () => {
+  assert.equal(
+    prefersFinePointer((query) => ({ matches: query.includes('pointer: fine') })),
+    true,
+  );
+  assert.equal(prefersFinePointer(() => ({ matches: false })), false);
+  assert.equal(prefersFinePointer(undefined), true);
+});
+
+test('touchpad zoom scale is ~2.5× Cesium wheel and maps pixels to altitude', () => {
+  assert.equal(TOUCHPAD_WHEEL_ZOOM_SCALE, 0.002);
+  // Cesium ≈ 5 * 7.5°/px / canvasHeight ≈ 0.000727 on a 900px view.
+  const cesiumScaleAt900px = (5 * 7.5 * Math.PI / 180) / 900;
+  assert.ok(TOUCHPAD_WHEEL_ZOOM_SCALE / cesiumScaleAt900px >= 2);
+  assert.ok(TOUCHPAD_WHEEL_ZOOM_SCALE / cesiumScaleAt900px <= 2.8);
+  assert.equal(zoomAmountFromWheelPixels(0, 2000), 0);
+  assert.equal(zoomAmountFromWheelPixels(10, 2000), 40);
+  assert.equal(zoomAmountFromWheelPixels(-10, NaN), -20);
+});
+
+test('pinch and continuous two-finger scroll share the touchpad zoom path', () => {
+  assert.equal(isTouchpadZoomWheel({ ctrlKey: true, deltaX: 0, deltaY: -20, deltaMode: 0 }), true);
+  assert.equal(isTouchpadZoomWheel({ ctrlKey: false, deltaX: 0, deltaY: 16, deltaMode: 0 }), true);
+  assert.equal(isTouchpadZoomWheel({ ctrlKey: false, deltaX: -24, deltaY: 2, deltaMode: 0 }), true);
+  assert.equal(isTouchpadZoomWheel({ ctrlKey: false, deltaX: 0, deltaY: 120, deltaMode: 0 }), false);
+  assert.equal(isTouchpadZoomWheel({ ctrlKey: false, deltaX: 0, deltaY: 2, deltaMode: 1 }), false);
+});
+
+test('installTouchpadCamera binds Ctrl+wheel zoom, filters laptop pinch-tilt, and disposes', () => {
+  const listeners = [];
+  const zoomIns = [];
+  const canvas = {
+    addEventListener(type, handler, options) {
+      listeners.push({ type, handler, options });
+    },
+    removeEventListener(type, handler) {
+      const index = listeners.findIndex((entry) => entry.type === type && entry.handler === handler);
+      if (index >= 0) listeners.splice(index, 1);
+    },
+  };
+  const controller = {
+    enableInputs: true,
+    enableZoom: true,
+    zoomEventTypes: [
+      Cesium.CameraEventType.RIGHT_DRAG,
+      Cesium.CameraEventType.WHEEL,
+      Cesium.CameraEventType.PINCH,
+    ],
+    tiltEventTypes: [
+      Cesium.CameraEventType.MIDDLE_DRAG,
+      Cesium.CameraEventType.PINCH,
+    ],
+  };
+  const viewer = {
+    scene: { canvas, screenSpaceCameraController: controller },
+    camera: {
+      positionCartographic: { height: 2000 },
+      zoomIn(amount) { zoomIns.push(amount); },
+    },
+  };
+
+  const dispose = installTouchpadCamera(viewer);
+  assert.equal(installTouchpadCamera(viewer), dispose);
+  assert.ok(controller.zoomEventTypes.some((entry) => (
+    entry?.eventType === Cesium.CameraEventType.WHEEL
+    && entry?.modifier === Cesium.KeyboardEventModifier.CTRL
+  )));
+  assert.ok(!controller.tiltEventTypes.includes(Cesium.CameraEventType.PINCH));
+  assert.ok(controller.zoomEventTypes.includes(Cesium.CameraEventType.PINCH));
+  assert.ok(controller.zoomEventTypes.includes(Cesium.CameraEventType.WHEEL));
+
+  const wheel = listeners.find((entry) => entry.type === 'wheel');
+  assert.equal(wheel.options.capture, true);
+  assert.equal(wheel.options.passive, false);
+
+  const prevented = [];
+  const stopped = [];
+  wheel.handler({
+    ctrlKey: true,
+    metaKey: false,
+    deltaX: 0,
+    deltaY: -20,
+    deltaMode: 0,
+    preventDefault() { prevented.push('pinch'); },
+    stopImmediatePropagation() { stopped.push('pinch'); },
+  });
+  assert.deepEqual(prevented, ['pinch']);
+  assert.deepEqual(stopped, ['pinch']);
+  assert.deepEqual(zoomIns, [80]);
+
+  wheel.handler({
+    ctrlKey: false,
+    metaKey: false,
+    deltaX: 0,
+    deltaY: 16,
+    deltaMode: 0,
+    preventDefault() { prevented.push('vertical'); },
+    stopImmediatePropagation() { stopped.push('vertical'); },
+  });
+  assert.deepEqual(prevented, ['pinch', 'vertical']);
+  assert.deepEqual(stopped, ['pinch', 'vertical']);
+  assert.deepEqual(zoomIns, [80, -64]);
+
+  wheel.handler({
+    ctrlKey: false,
+    metaKey: false,
+    deltaX: 40,
+    deltaY: 0,
+    deltaMode: 0,
+    preventDefault() { prevented.push('horizontal'); },
+    stopImmediatePropagation() { stopped.push('horizontal'); },
+  });
+  assert.deepEqual(prevented, ['pinch', 'vertical', 'horizontal']);
+  assert.deepEqual(zoomIns, [80, -64, -160]);
+
+  wheel.handler({
+    ctrlKey: false,
+    metaKey: false,
+    deltaX: 0,
+    deltaY: 120,
+    deltaMode: 0,
+    preventDefault() { prevented.push('mouse'); },
+    stopImmediatePropagation() { stopped.push('mouse'); },
+  });
+  assert.ok(!prevented.includes('mouse'));
+  assert.deepEqual(zoomIns, [80, -64, -160]);
+
+  controller.enableInputs = false;
+  wheel.handler({
+    ctrlKey: true,
+    deltaX: 0,
+    deltaY: -20,
+    deltaMode: 0,
+    preventDefault() { prevented.push('disabled'); },
+  });
+  assert.ok(!prevented.includes('disabled'));
+
+  dispose();
+  assert.equal(listeners.length, 0);
+});

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,6 @@
 import * as Cesium from 'cesium';
 import { StyleManager } from './ui.js';
-import { flyToAustin } from './camera.js';
+import { flyToAustin, installTouchpadCamera } from './camera.js';
 import { DataLayerManager } from './data/manager.js';
 import flightsLayer from './data/flights.js';
 import militaryFlightsLayer from './data/militaryFlights.js';
@@ -132,6 +132,11 @@ async function init() {
     // 2026-08-05 perf investigation as a strict halving of idle burn on
     // 120 Hz hardware; a no-op on 60 Hz displays. (perf item 2)
     viewer.targetFrameRate = 60;
+
+    // Precision Touchpad pinch is Ctrl+wheel; Cesium only zooms unmodified
+    // wheel. Bind that (and keep two-finger scroll from tilting) without
+    // changing mouse wheel or touch-screen pinch-zoom.
+    installTouchpadCamera(viewer);
 
     // Register per-layer data attribution into the "Data attribution" popover.
     // Required by each source's license (ODbL, CC BY-NC-SA, NASA FIRMS, etc.);

--- a/style.css
+++ b/style.css
@@ -53,6 +53,7 @@ html, body {
   position: absolute;
   top: 0;
   left: 0;
+  touch-action: none;
 }
 
 /* Unified world-overlay host: detection uses one host-owned blend surface


### PR DESCRIPTION
## Summary

- Windows Precision Touchpad pinch arrives as Ctrl+wheel. Cesium recorded that event but only zoomed unmodified wheel, so laptop pinch did nothing.
- Two-finger scroll could tilt/orbit when the pad also emitted touch. On a fine pointer this PR maps pinch and continuous two-finger motion to a height-scaled zoom (`0.002 × altitude × wheel Δ`, about 2.5–2.7× Cesium's wheel) and drops unmodified PINCH from tilt.
- Click-drag orbit, Ctrl+drag tilt, discrete mouse-wheel notches, and touch-screen pinch-zoom stay on Cesium.

## Test plan

- [ ] On a Windows Precision Touchpad laptop, pinch-zoom the globe (should zoom, not page-zoom the UI).
- [ ] Two-finger scroll zooms; it should not tilt.
- [ ] Mouse wheel notches still zoom at Cesium's existing feel.
- [ ] Click-drag orbit and Ctrl+drag tilt are unchanged.
- [ ] `npm test` (includes `src/cameraTouchpad.test.mjs`).