### PR TITLE
fix: reject impossible ground samples that hide local-layer markers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,11 @@ of current runtime behavior, see [`docs/CURRENT-STATE.md`](docs/CURRENT-STATE.md
 
 ### Fixed
 
+- Datacenter, dam, and other local-dataset markers no longer disappear at close
+  range over a still-streaming photorealistic tileset. A height sample from
+  under the surface is now rejected rather than trusted, so the marker waits at
+  ellipsoid height for a real one instead of being rebuilt kilometres
+  underground and hidden.
 - A missing optional FIRMS key no longer turns the complete Environmental
   mission into `LOAD FAILED`. The FIRMS row still reports `KEY REQUIRED`, while
   earthquakes continue to load. Real lifecycle and fetch failures retain

--- a/docs/CURRENT-STATE.md
+++ b/docs/CURRENT-STATE.md
@@ -1024,7 +1024,15 @@ This is the current runtime/source-of-truth snapshot for the project.
 >   Stem position and
 >   polyline properties are constant between initialization, camera `moveEnd`,
 >   and successful near-surface ground samples rather than per-frame callbacks
->   or every 450 ms visibility pass. Unchanged or sub-0.5 m tips do not call
+>   or every 450 ms visibility pass. A ground sample counts as successful only
+>   inside an asymmetric plausible-surface band (`isPlausibleGroundHeight`,
+>   -500 m to 9,000 m above the ellipsoid). A partially-streamed photoreal
+>   tileset returns samples around -6,600 m, which the earlier symmetric
+>   `|sampled| > 9000` test accepted, rebuilding every stem far below the
+>   surface where the horizon occluder hid it while `getStats()` still reported
+>   a full feature count. An implausible sample leaves the record unsampled, so
+>   it keeps its bounded retry and draws from ellipsoid zero meanwhile.
+>   Unchanged or sub-0.5 m tips do not call
 >   `setValue`, and each record alternates between two preallocated two-position
 >   stem arrays so real tip changes notify Cesium without steady-state allocation.
 >   Shared placement records retain the raw anchor plus one signed integer

--- a/src/data/localGeojson.js
+++ b/src/data/localGeojson.js
@@ -29,7 +29,21 @@ const LOCAL_OVERLAY_FADE_START_RATIO = LOCAL_OVERLAY_FADE_START_M / LOCAL_OVERLA
 // height once per feature and lift the stem onto it.
 const GROUND_SAMPLE_MAX_DISTANCE_M = 75000;
 const GROUND_SAMPLE_RETRY_MS = 2000;
-const GROUND_SAMPLE_MAX_ABS_HEIGHT_M = 9000;
+/**
+ * Plausible-surface band for a ground sample, in metres above the WGS84
+ * ellipsoid. Deliberately ASYMMETRIC, because the Earth is: real surfaces run
+ * from about -430 m (Dead Sea shore, ≈ -400 m ellipsoidal there) up to 8,849 m.
+ *
+ * A symmetric `Math.abs(sampled) > 9000` guard let `scene.sampleHeight` return
+ * ≈ -6,600 m over a partially-streamed Google photoreal tileset and be accepted
+ * as ground. Every stem was then rebuilt 6.6 km underground, where the horizon
+ * occluder correctly hid it — so the whole layer vanished at close range while
+ * still reporting a healthy feature count. Rejecting the sample instead leaves
+ * the record unsampled, so it retries and meanwhile draws from ellipsoid zero,
+ * which is the pre-existing keyless behaviour.
+ */
+const GROUND_SAMPLE_MIN_HEIGHT_M = -500;
+const GROUND_SAMPLE_MAX_HEIGHT_M = 9000;
 /**
  * Bounded give-up for the self-armed retry. Sampling can be SUPPORTED and still
  * never succeed (no sampleable surface under the feature), in which case each
@@ -758,6 +772,17 @@ function insertLocalCellContender(contenders, record) {
   if (contenders.length > LOCAL_OVERLAY_CELL_SURPLUS) contenders.length = LOCAL_OVERLAY_CELL_SURPLUS;
 }
 
+/**
+ * Whether a `scene.sampleHeight` result can be a real surface.
+ * @param {*} sampled Raw sample, which may be undefined when no tile was hit.
+ * @returns {boolean}
+ */
+export function isPlausibleGroundHeight(sampled) {
+  return Number.isFinite(sampled)
+    && sampled >= GROUND_SAMPLE_MIN_HEIGHT_M
+    && sampled <= GROUND_SAMPLE_MAX_HEIGHT_M;
+}
+
 function sampleLocalGroundHeight(viewer, record, now) {
   if (record.groundSampled || !viewer.scene.sampleHeightSupported) return false;
   if (now - record.lastGroundSampleMs < GROUND_SAMPLE_RETRY_MS) return false;
@@ -768,7 +793,7 @@ function sampleLocalGroundHeight(viewer, record, now) {
   } catch {
     return false; // tiles not ready; retry on a later bounded update
   }
-  if (!Number.isFinite(sampled) || Math.abs(sampled) > GROUND_SAMPLE_MAX_ABS_HEIGHT_M) return false;
+  if (!isPlausibleGroundHeight(sampled)) return false;
   record.groundSampled = true;
   record.groundHeight = sampled;
   Cesium.Cartesian3.fromRadians(

--- a/src/data/localGeojson.test.mjs
+++ b/src/data/localGeojson.test.mjs
@@ -9,6 +9,7 @@ import {
   createLocalGeoJsonLayer,
   createLocalInfrastructureOverlayEntry,
   createLocalInfrastructureOverlayPublisher,
+  isPlausibleGroundHeight,
   localDatasetError,
   localInfrastructureOverlayCopy,
   selectLocalInfrastructureOverlayCohort,
@@ -961,5 +962,67 @@ test('after the cap a camera-motion frame still samples, and re-opens the budget
     governorScene.renders,
     GROUND_SAMPLE_MAX_ARMED_RETRIES,
     'a grounded record asks for no further frames',
+  );
+});
+
+// ── A sample can be finite and still impossible ───────────────────────────────
+//
+// Over a partially-streamed photoreal tileset, scene.sampleHeight returns
+// values around -6,600 m. The old guard was symmetric (|sampled| > 9000), so
+// those were accepted as ground and every stem was rebuilt 6.6 km below the
+// ellipsoid, where the horizon occluder correctly hid it. getStats() still
+// reported every feature loaded with error: null, so nothing failed loudly —
+// the markers were simply not on screen at close range.
+
+test('a ground sample below any real surface is rejected, not accepted as ground', () => {
+  // The sample that caused this, and the rest of the impossible sub-surface band.
+  assert.equal(isPlausibleGroundHeight(-6600), false);
+  assert.equal(isPlausibleGroundHeight(-8999), false);
+
+  // Real surfaces, which must still be accepted. The band is asymmetric because
+  // the Earth is: about -430 m at the Dead Sea shore, up to 8,849 m.
+  assert.equal(isPlausibleGroundHeight(0), true);
+  assert.equal(isPlausibleGroundHeight(164), true);
+  assert.equal(isPlausibleGroundHeight(-400), true, 'Dead Sea shore');
+  assert.equal(isPlausibleGroundHeight(8849), true, 'Everest');
+
+  // Above any surface, and the non-numeric values sampleHeight really returns
+  // when no tile is hit.
+  assert.equal(isPlausibleGroundHeight(9001), false);
+  assert.equal(isPlausibleGroundHeight(undefined), false);
+  assert.equal(isPlausibleGroundHeight(NaN), false);
+});
+
+test('an impossible sample leaves the record ungrounded and still recoverable', async (t) => {
+  const env = await createRealLocalLayerHarness({ sampleHeightSupported: true });
+  _resetRenderGovernorForTest();
+  installRenderGovernor({ scene: { requestRender() {} } });
+  t.mock.timers.enable({ apis: ['setTimeout'] });
+  const clock = installFakeClock(t);
+  t.after(() => {
+    env.layer.destroy(env.viewer);
+    env.cleanup();
+    _resetRenderGovernorForTest();
+  });
+
+  setCameraAltitude(env, 20_000);
+  env.setSampleHeight(() => -6600);
+  runArmedRetryChain(env, t, clock, 3);
+  assert.equal(
+    baseHeightM(env),
+    0,
+    'a sub-surface sample must leave the stem at ellipsoid height, not 6.6 km under it',
+  );
+
+  // Rejecting rather than accepting keeps the record unsampled, so the tiles
+  // arriving later still ground it.
+  env.setSampleHeight(() => 114);
+  setCameraAltitude(env, 19_000);
+  env.moveEnd.raise();
+  clock.advance(2_100);
+  env.preRender.raise();
+  assert.ok(
+    Math.abs(baseHeightM(env) - 114) < 1e-6,
+    `a rejected sample must not end the retry; base height ${baseHeightM(env)}`,
   );
 });


### PR DESCRIPTION
## The bug

Over a partially-streamed Google photoreal tileset, `scene.sampleHeight` returns values around **-6,600 m**. The plausibility guard in `localGeojson.js` was symmetric:

```js
if (!Number.isFinite(sampled) || Math.abs(sampled) > GROUND_SAMPLE_MAX_ABS_HEIGHT_M) return false; // 9000
```

so -6,600 passed, was accepted as ground, and every stem in the layer was rebuilt 6.6 km below the ellipsoid, where the horizon occluder correctly hid it.

The failure mode is the bad part. `getStats()` still reported every feature loaded with `error: null`, so the layer chip stayed green and nothing logged. The markers were simply **not on screen at close range**, while rendering fine at country zoom and on every globe stack, which reads as a rendering quirk rather than bad data.

## The fix

The Earth is not symmetric, so the band should not be either. Real surfaces run from about -430 m (Dead Sea shore) to 8,849 m:

```js
const GROUND_SAMPLE_MIN_HEIGHT_M = -500;
const GROUND_SAMPLE_MAX_HEIGHT_M = 9000;
```

A sub-surface sample is now rejected rather than trusted. Rejecting leaves the record **unsampled**, which matters: it keeps its place on the existing bounded retry schedule and draws from ellipsoid zero meanwhile, which is the pre-existing keyless behaviour. Nothing about the retry budget, the capability gate, or the render-governor interaction changes.

Measured on a dams-layer feature, camera at 20 km:

```
before   base -6,606 m   hidden
after    base    114 m   drawn on the real surface
```

## Tests

Two, both in `src/data/localGeojson.test.mjs`:

1. A unit test on the newly exported `isPlausibleGroundHeight`, pinning the -6,600 m case, both real-surface extremes, and the `undefined`/`NaN` that `sampleHeight` actually returns when no tile is hit.
2. A behavioural test on the existing `createRealLocalLayerHarness`: drive `sampleHeight` at -6600, assert the stem stays at ellipsoid height, then let a later good sample ground it. **It fails against the old symmetric guard** — I reverted the source line to check, and it was the only failure of the 24 in that file.

## Verification

- `npm run build` clean.
- `npm test`: 2,589 passed, 0 failed.
- `npm run test:track`: 96 passed, 4 failed on my machine. None relate to this diff. Three are `no console errors` assertions failing on a `403` from `tile.googleapis.com`, which my Google billing account gets unconditionally under Google's EEA Map Tiles terms and which Chrome logs before any code can catch. The fourth (`ground-3d: ... probes are one-shot/per-poll bounded`, expecting ≥4 `sampleHeight` calls, seeing 3) **fails identically on a branch of mine that does not touch ground sampling at all**, and the invariant it guards still holds: growth over ~60 frames was 1, against ~60+ for per-frame sampling.

## Docs updated

`CHANGELOG.md` (Fixed) and `docs/CURRENT-STATE.md`, under the local-infrastructure layer contract where the stem/ground-sample rules already live.
