### PR TITLE
fix(proxy): add IPv4 fallback and log cause for FIRMS on Node 24 (#68)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 This changelog records public product changes. For the authoritative description
 of current runtime behavior, see [`docs/CURRENT-STATE.md`](docs/CURRENT-STATE.md).
 
+## [Unreleased]
+
+### Fixed
+
+- Added targeted IPv4 fallback (`family: 4` via `node:https`) for NASA FIRMS proxy requests in `vite.config.js` when Node 24 standard `fetch()` fails due to IPv6 connection timeouts on unrouted hosts. (#68)
+- Enhanced FIRMS proxy error logging to surface `error.cause` alongside error messages instead of masking connection failures as generic `fetch failed`. (#68)
+
 ## [Unreleased] — 2026-08-24
 
 ### Added

--- a/docs/CURRENT-STATE.md
+++ b/docs/CURRENT-STATE.md
@@ -143,6 +143,12 @@ Updated: August 24, 2026
 > no height sampling and no canvas work after the single clear on the disable
 > transition. The hard-crop (FEATHER 0) path honors the same terminus.
 
+> **FIRMS proxy IPv4 fallback (#68):**
+> `firmsProxy()` in `vite.config.js` executes standard `fetch()` first and falls
+> back to an explicit IPv4 (`family: 4`) request via `node:https` when standard
+> `fetch()` fails due to IPv6 connection timeouts on unrouted hosts. Proxy logs
+> surface `error.cause` alongside error messages.
+
 This is the current runtime/source-of-truth snapshot for the project.
 
 > [!IMPORTANT]

--- a/vite.config.js
+++ b/vite.config.js
@@ -2012,15 +2012,53 @@ function firmsProxy() {
   }
 
   /**
+   * Fetch helper for FIRMS endpoints that handles Node 24 IPv6 auto-selection failures.
+   * Tries standard fetch() first. If fetch fails with a network connection error
+   * (e.g. ETIMEDOUT / ENETUNREACH / fetch failed when IPv6 is unrouted/unavailable),
+   * falls back to node:https GET with family: 4 (IPv4 explicit).  (Issue #68)
+   */
+  async function fetchFirmsWithFallback(url, timeoutMs = 60_000) {
+    try {
+      const res = await fetch(url, { signal: AbortSignal.timeout(timeoutMs) });
+      if (!res.ok) {
+        throw new Error(`HTTP ${res.status}`);
+      }
+      return await res.text();
+    } catch (err) {
+      if (err?.message?.startsWith('HTTP ')) throw err;
+
+      return new Promise((resolve, reject) => {
+        const req = https.get(url, { family: 4, timeout: timeoutMs }, (res) => {
+          if (res.statusCode < 200 || res.statusCode >= 300) {
+            reject(new Error(`HTTP ${res.statusCode}`));
+            return;
+          }
+          let data = '';
+          res.setEncoding('utf8');
+          res.on('data', (chunk) => { data += chunk; });
+          res.on('end', () => resolve(data));
+        });
+        req.on('timeout', () => {
+          req.destroy(new Error('timeout'));
+        });
+        req.on('error', (fallbackErr) => {
+          const finalErr = new Error(`fetch failed: ${err?.message || err}`);
+          finalErr.cause = err?.cause || fallbackErr;
+          reject(finalErr);
+        });
+      });
+    }
+  }
+
+  /**
    * Fetch + parse one FIRMS source. Throws on HTTP error or a non-CSV body
    * (FIRMS reports errors as HTML/plain text, never CSV). Never log the URL —
    * it embeds the MAP_KEY.
    */
   async function fetchSource(key, source) {
     const url = `https://firms.modaps.eosdis.nasa.gov/api/area/csv/${encodeURIComponent(key)}/${source}/world/2`;
-    const res = await fetch(url, { signal: AbortSignal.timeout(60_000) });
-    if (!res.ok) throw new Error(`HTTP ${res.status}`);
-    const records = parseFirmsCsv(await res.text());
+    const bodyText = await fetchFirmsWithFallback(url, 60_000);
+    const records = parseFirmsCsv(bodyText);
     if (records === null) throw new Error('non-CSV upstream response');
     return records;
   }
@@ -2041,7 +2079,8 @@ function firmsProxy() {
         sources.push({ source, count: records.length, ok: true });
         fires.push(...records);
       } catch (err) {
-        console.warn(`[firms-proxy] ${source} fetch failed:`, err?.message || err);
+        const detail = err?.cause ? `${err.message} (${err.cause.message || err.cause})` : (err?.message || err);
+        console.warn(`[firms-proxy] ${source} fetch failed:`, detail);
         sources.push({ source, count: 0, ok: false });
       }
     }
@@ -2075,14 +2114,14 @@ function firmsProxy() {
       statusInflight = (async () => {
         try {
           const url = `https://firms.modaps.eosdis.nasa.gov/mapserver/mapkey_status/?MAP_KEY=${encodeURIComponent(key)}`;
-          const res = await fetch(url, { signal: AbortSignal.timeout(10_000) });
-          if (!res.ok) throw new Error(`HTTP ${res.status}`);
-          const body = await res.json();
+          const bodyText = await fetchFirmsWithFallback(url, 10_000);
+          const body = JSON.parse(bodyText);
           const used = Number(body?.current_transactions);
           const limit = Number(body?.transaction_limit);
           return Number.isFinite(used) && Number.isFinite(limit) ? { used, limit } : null;
         } catch (err) {
-          console.warn('[firms-proxy] mapkey status failed:', err?.message || err);
+          const detail = err?.cause ? `${err.message} (${err.cause.message || err.cause})` : (err?.message || err);
+          console.warn('[firms-proxy] mapkey status failed:', detail);
           return null;
         }
       })()
@@ -2147,7 +2186,8 @@ function firmsProxy() {
                 return fresh;
               })
               .catch((err) => {
-                console.warn(`[firms-proxy] refresh failed (${err?.message || err}) — serving cache if any`);
+                const detail = err?.cause ? `${err.message} (${err.cause.message || err.cause})` : (err?.message || err);
+                console.warn(`[firms-proxy] refresh failed (${detail}) — serving cache if any`);
                 return null;
               })
               .finally(() => { inflight = null; });
@@ -2162,7 +2202,8 @@ function firmsProxy() {
             sendJson(502, { error: 'firms fetch failed and no cache available' });
           }
         } catch (err) {
-          console.warn('[firms-proxy] error:', err?.message || err);
+          const detail = err?.cause ? `${err.message} (${err.cause.message || err.cause})` : (err?.message || err);
+          console.warn('[firms-proxy] error:', detail);
           sendJson(500, { error: 'firms proxy error' });
         }
       });


### PR DESCRIPTION
Closes #68 

- Implement fetchFirmsWithFallback() in vite.config.js using node:https with family: 4 fallback when standard fetch fails on Node 24 IPv6 connection timeouts (#68)
- Update error logging across firmsProxy() to surface error.cause context instead of masking errors as generic fetch failed (#68)
- Update CHANGELOG.md and docs/CURRENT-STATE.md per project contribution guidelines