### PR TITLE
feat: boot diagnostics on the loading screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ of current runtime behavior, see [`docs/CURRENT-STATE.md`](docs/CURRENT-STATE.md
 
 ### Added
 
+- Added boot diagnostics to the loading screen: a module-load failure now
+  shows `Boot error: <message> @ <file>:<line>` instead of an eternal
+  "Initializing photorealistic world…", and a boot still waiting on modules
+  after 20 s says so with a running counter. Lives in `src/bootDiagnostics.js`,
+  loaded from `index.html` before `main.js` so it also covers a module that
+  fails to load, not only one that throws.
 - Added honest aircraft identity narration: callsign, operator, registration,
   type, and route come only from selected-contact context, and missing operator,
   route, or type enrichment is named explicitly.

--- a/docs/CURRENT-STATE.md
+++ b/docs/CURRENT-STATE.md
@@ -1,6 +1,15 @@
 # God's Eye View Current State
 
-Updated: August 24, 2026
+Updated: August 27, 2026
+
+> **2026-08-27 — boot diagnostics** (`src/bootDiagnostics.js`, a module with
+> no imports loaded from `index.html` before `main.js`). The `error` event on
+> `window` (capture phase, so a module that fails to load is caught as well as
+> one that throws) and `unhandledrejection` replace the loading-screen status
+> with `Boot error: …` in red; if `main.js` has not replaced the initial
+> status after 20 s the line grows a seconds counter and a slow-network hint.
+> Both stop as soon as the loading screen is dismissed or `main.js` takes
+> over. No behavior change on a successful boot.
 
 > **2026-08-23 — first-run mission launcher** (`src/firstRunExperience.js`,
 > `#first-run-launcher`, styles at the tail of `style.css`). After startup

--- a/index.html
+++ b/index.html
@@ -894,6 +894,9 @@
     </div>
   </div>
 
+  <!-- Before main.js on purpose: module scripts run in document order and the
+       boot listeners have to exist before the app graph starts evaluating. -->
+  <script type="module" src="/src/bootDiagnostics.js"></script>
   <script type="module" src="/src/main.js"></script>
 </body>
 </html>

--- a/src/bootDiagnostics.js
+++ b/src/bootDiagnostics.js
@@ -1,0 +1,122 @@
+/**
+ * Boot diagnostics for the loading screen.
+ *
+ * main.js replaces the loader status on its first line, so when the module
+ * graph fails to load or throws while evaluating, the screen stays on
+ * "Initializing photorealistic world…" forever and nothing explains why.
+ * Phones have no console to look at. This module reports those failures on
+ * the loading screen itself, and past a threshold says that the boot is slow
+ * rather than dead.
+ *
+ * It is loaded from index.html before main.js on purpose: module scripts run
+ * in document order, and the listeners below have to exist before main.js
+ * and its imports start evaluating. It has no imports of its own so that it
+ * cannot fail for the same reason it is watching for.
+ *
+ * @module bootDiagnostics
+ */
+
+// Past this, a boot that has not handed over to main.js is reported as slow.
+const BOOT_SLOW_AFTER_MS = 20000;
+
+// How often the slow-boot check runs. Coarse on purpose: it only updates a
+// label, and the label already has a seconds counter.
+const BOOT_POLL_MS = 5000;
+
+// Enough of a message or stack to be useful in a screenshot. The loader is a
+// status line, not a console.
+const BOOT_ERROR_MAX_CHARS = 400;
+
+// Reference point for the seconds counter shown on a slow boot.
+const bootStartedAt = Date.now();
+
+/**
+ * The status line inside the loading screen, or null once the screen is gone.
+ * Queried on every use because main.js owns that element from its first line.
+ * @returns {HTMLElement|null}
+ */
+function loaderStatusElement() {
+  return document.querySelector('#loading-screen .loader-status');
+}
+
+/**
+ * Whether the loading screen is still what the user sees. Both properties are
+ * checked because the dismiss animation fades opacity to 0 before the screen
+ * is finally set to display: none.
+ * @returns {boolean}
+ */
+function loadingScreenVisible() {
+  const loadingScreen = document.getElementById('loading-screen');
+  if (!loadingScreen) return false;
+
+  const style = getComputedStyle(loadingScreen);
+  return style.display !== 'none' && style.opacity !== '0';
+}
+
+/**
+ * Replace the loading status with a red boot error. Does nothing once the
+ * loading screen is gone: after a successful boot, errors belong to the app's
+ * own handling, not to this module.
+ * @param {string} message - Error text; truncated to BOOT_ERROR_MAX_CHARS.
+ */
+function showBootError(message) {
+  const loaderStatus = loaderStatusElement();
+  if (!loaderStatus || !loadingScreenVisible()) return;
+
+  loaderStatus.textContent = `Boot error: ${String(message).slice(0, BOOT_ERROR_MAX_CHARS)}`;
+  loaderStatus.style.color = '#ff4444';
+  loaderStatus.style.whiteSpace = 'pre-wrap';
+}
+
+/**
+ * Turn an error event into one line for the loader. A resource that failed to
+ * load (a module script, a stylesheet) carries no message, only the element
+ * whose src or href failed; a thrown error carries message, file and line.
+ * @param {ErrorEvent|Event} event - From the window 'error' listener.
+ * @returns {string}
+ */
+function describeErrorEvent(event) {
+  const failedUrl = event.target?.src || event.target?.href;
+  if (failedUrl && !(event instanceof ErrorEvent)) {
+    return `failed to load ${String(failedUrl).replace(window.location.origin, '')}`;
+  }
+
+  const sourceLocation = event.filename
+    ? ` @ ${event.filename.replace(window.location.origin, '')}:${event.lineno}`
+    : '';
+  return (event.message || event.error?.message || 'script error') + sourceLocation;
+}
+
+// Capture phase, because a failed script or module fetch fires 'error' on the
+// element itself and never bubbles up to the window. Thrown errors, including
+// one inside main.js or any of its imports, arrive here as well.
+window.addEventListener('error', (event) => {
+  showBootError(describeErrorEvent(event));
+}, true);
+
+// A rejected promise nobody caught (a failed dynamic import, a fetch inside
+// init()) is the other way a boot dies without a word.
+window.addEventListener('unhandledrejection', (event) => {
+  const reason = event.reason;
+  showBootError(reason?.message || reason?.stack || String(reason));
+});
+
+// What index.html shipped in the status line. main.js overwrites it on its
+// first line, which is how "main.js has taken over" is detected below.
+const initialStatusText = loaderStatusElement()?.textContent;
+
+// While the status text is still the initial one, main.js has not run. Past
+// the threshold, say so with a counter instead of looking hung; stop as soon
+// as main.js takes over or the loading screen goes away.
+const slowBootTimer = setInterval(() => {
+  const loaderStatus = loaderStatusElement();
+  if (!loaderStatus || !loadingScreenVisible() || loaderStatus.textContent !== initialStatusText) {
+    clearInterval(slowBootTimer);
+    return;
+  }
+
+  const elapsedSeconds = Math.round((Date.now() - bootStartedAt) / 1000);
+  if (elapsedSeconds >= BOOT_SLOW_AFTER_MS / 1000) {
+    loaderStatus.textContent = `${initialStatusText} (${elapsedSeconds}s — still downloading modules; slow network?)`;
+  }
+}, BOOT_POLL_MS);


### PR DESCRIPTION
Hi Bilawal, first of all thanks for opening this. I put it on a VPS this week and it is a lot of fun.

Small one, and **I checked the open PRs and issues first**: nothing touches the loading screen. When I opened it on my phones the loading screen stayed on "Initializing photorealistic world..." forever and there was no way to know why (no console on a phone). It turned out it was just slow (the dev server sends a 10 MB `cesium.js` and my nginx was not compressing it), but I only found that out reading the nginx access log.

So this adds `src/bootDiagnostics.js`, a small module with no imports, loaded from `index.html` right before `main.js`. It does **two things**. If any error or unhandled rejection happens during boot, the status line shows "Boot error: message @ file:line" in red. And if after 20 seconds `main.js` has still not replaced the initial text, the line grows a seconds counter and a "still downloading modules; slow network?" hint. Both stop as soon as `main.js` takes over or the loading screen goes away, so on a normal boot nothing changes.

**It is loaded before `main.js` on purpose:** module scripts run in document order, so the listeners exist before the app graph starts evaluating. A failed import inside that graph never reaches the try/catch in `init()`, and that is exactly the case that used to look like a hang; the error listener uses the capture phase so a module that fails to load is reported too, not only one that throws.

**Verified** on an iPhone (Edge iOS, WebKit) and a Galaxy S24 (Chrome): when the boot is slow the counter shows up, and then the app loads as usual. Desktop unchanged. `npm test`, `npm run build` and `npm run test:track` are green. `CHANGELOG.md` and `docs/CURRENT-STATE.md` updated.

One more thing for whoever runs this behind nginx, since it is what made my phones slow in the first place. Vite serves the modules as `text/javascript`, and the usual nginx gzip config only lists `application/javascript`, so the dev `cesium.js` (10 MB, not minified) is sent uncompressed.

With this in the server block it drops to **about 2 MB**:

    gzip on;
    gzip_vary on;
    gzip_proxied any;
    gzip_comp_level 6;
    gzip_min_length 1024;
    gzip_types text/plain text/css text/javascript application/javascript application/json application/wasm image/svg+xml;

To be clear, **this is an nginx thing**. Caddy, Traefik, Apache with the default mod_deflate and Cloudflare all compress `text/javascript` by default, and Vite itself never compresses, it leaves that to whatever is in front. It only happens with nginx and the usual copy-paste gzip block, which is probably the most common setup for this. Not part of the code change, just leaving it here in case it helps. If you want it in the README "Sharing an instance" section I can add it.

Let me know if you prefer the text or the threshold different. Have a great day!

