### PR TITLE
feat: lighter rendering on phones (mobile profile)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ of current runtime behavior, see [`docs/CURRENT-STATE.md`](docs/CURRENT-STATE.md
 
 ### Added
 
+- Added a lighter rendering profile for phones and small tablets
+  (`src/mobileProfile.js`): no preserved drawing buffer, CSS-pixel
+  resolution, a 256 MB photoreal tile cache with coarser detail,
+  and the post-process passes (scope mask, sharpen, bloom, visual styles)
+  disabled. Desktop rendering is unchanged. `?gevMobile=1|0` forces the
+  profile; `?gevFlags=diag` shows an on-screen GPU/canvas readout for bug
+  reports. See `docs/KNOWN-ISSUES.md`, "Phones and small tablets".
 - Added honest aircraft identity narration: callsign, operator, registration,
   type, and route come only from selected-contact context, and missing operator,
   route, or type enrichment is named explicitly.

--- a/docs/CURRENT-STATE.md
+++ b/docs/CURRENT-STATE.md
@@ -1,6 +1,21 @@
 # God's Eye View Current State
 
-Updated: August 24, 2026
+Updated: August 27, 2026
+
+> **2026-08-27 — mobile rendering profile** (`src/mobileProfile.js`, applied
+> in `src/main.js`). `isMobileDevice()` is true for touch-first devices whose
+> shorter screen side is under 900 px (`?gevMobile=1|0` overrides). On those
+> the viewer is created with `preserveDrawingBuffer: false` (MSAA stays 4x),
+> `useBrowserRecommendedResolution` is forced on, the Google tileset gets `cacheBytes` 256 MB / `maximumCacheOverflowBytes` 64 MB /
+> `maximumScreenSpaceError` 24, the scope mask is switched off right after
+> install, and every post-process stage plus FXAA and bloom is disabled after
+> the `StyleManager` registers them (`[mobile] post-process disabled (n
+> stages)` in the console). `window.__gevMobile === true` marks the active
+> profile. Desktop keeps the upstream values exactly.
+>
+> `?gevFlags=diag` installs `#gev-diag`, a fixed readout of browser, GPU,
+> DPR, canvas vs. drawing-buffer size, GL limits and active profile, meant
+> for phone bug reports. Without the flag nothing is added.
 
 > **2026-08-23 — first-run mission launcher** (`src/firstRunExperience.js`,
 > `#first-run-launcher`, styles at the tail of `style.css`). After startup

--- a/docs/KNOWN-ISSUES.md
+++ b/docs/KNOWN-ISSUES.md
@@ -1,6 +1,6 @@
 # KNOWN ISSUES
 
-Updated: July 8, 2026
+Updated: August 27, 2026
 
 This file tracks active runtime issues only.
 
@@ -63,6 +63,34 @@ Status: Open (accepted 2026-07-08, documented)
   the height-datum section in `docs/CURRENT-STATE.md`.
 
 ---
+
+## Phones and small tablets
+
+The app is built for a desktop GPU. On a phone it now runs a lighter
+rendering profile (`src/mobileProfile.js`), which is why the picture is a bit
+softer there: CSS-pixel resolution instead of 2x or 3x, a smaller photoreal
+tile cache with coarser detail, and none of the visual
+styles or the sharpen/bloom/scope passes. That is the trade for a globe that
+keeps running instead of stalling or, on iOS, reloading the tab when WebGL
+memory goes past roughly 1 to 1.5 GB.
+
+- Want desktop quality on a tablet? Add `?gevMobile=0` to the URL.
+  `?gevMobile=1` forces the phone profile on a desktop, useful to test it.
+- Something looks wrong on your phone? Open the site with `?gevFlags=diag`
+  and attach a screenshot of the green box in the top-left corner to your
+  issue. It lists browser, GPU, device pixel ratio, canvas and drawing-buffer
+  sizes and GL limits, which is what is needed to tell an app problem from a
+  browser or driver problem.
+- Known case, not fixable in the app: on a Galaxy S24 (Samsung Xclipse 940
+  GPU) Edge 151 for Android draws vertical streaks over the whole map. Chrome
+  on the same phone is fine, and the `diag` box shows the same GPU and Vulkan
+  backend in both, so it is Edge's default graphics backend, not Cesium. The
+  fix is on the phone: open `edge://flags` in Edge, search for "ANGLE",
+  set "Choose ANGLE graphics backend" to **Vulkan** (not OpenGL ES, that one
+  stays broken), tap Restart, and reload the site. Setting it back to Default
+  brings the streaks back.
+- The HUD layout itself is still a desktop layout; panels overlap on a
+  narrow screen. Not addressed by the profile.
 
 ## Closed / Intentional (for clarity)
 

--- a/src/main.js
+++ b/src/main.js
@@ -30,7 +30,14 @@ import {
   holdContinuousRender,
   releaseContinuousRender,
 } from './renderGovernor.js';
-import { installScopeMask } from './scopeMask.js';
+import { installScopeMask, setScopeMaskEnabled } from './scopeMask.js';
+import {
+  activeProfile,
+  isMobileDevice,
+  applyTilesetProfile,
+  disableAllPostProcess,
+  installDiagOverlay,
+} from './mobileProfile.js';
 import { initFirstRunExperience } from './firstRunExperience.js';
 
 initLogoGaze();
@@ -89,6 +96,12 @@ async function init() {
     // Expose API key globally for geocoding in locations.js
     window.__GOOGLE_MAPS_API_KEY__ = googleApiKey;
 
+    // Phones get lighter rendering settings (src/mobileProfile.js). Decided
+    // once, before the viewer exists, because MSAA and the drawing buffer are
+    // constructor options that cannot change later.
+    const mobile = isMobileDevice();
+    const deviceProfile = activeProfile();
+
     // Create the Cesium viewer with minimal chrome
     const viewer = new Cesium.Viewer('cesiumContainer', {
       timeline: false,
@@ -116,13 +129,20 @@ async function init() {
         document.body.appendChild(el);
         return el;
       })(),
-      msaaSamples: 4,
+      msaaSamples: deviceProfile.msaaSamples,
       contextOptions: {
         webgl: {
-          preserveDrawingBuffer: true,
+          preserveDrawingBuffer: deviceProfile.preserveDrawingBuffer,
         },
       },
     });
+
+    if (mobile) {
+      // Render at CSS pixels: a 3x device pixel ratio triples the fill cost.
+      viewer.useBrowserRecommendedResolution = true;
+      // Read by the diag readout and by anyone debugging from the console.
+      window.__gevMobile = true;
+    }
 
     // Cap the default render loop at 60 fps. Cesium's loop otherwise runs at
     // the display's refresh rate — 120 Hz on ProMotion panels — doubling GPU
@@ -160,6 +180,8 @@ async function init() {
       tileset = await Cesium.createGooglePhotorealistic3DTileset({
         onlyUsingWithGoogleGeocoder: true,
       });
+      // Cache and detail limits; a no-op on desktop.
+      applyTilesetProfile(tileset, deviceProfile);
       viewer.scene.primitives.add(tileset);
       // NOTE: Cesium World Terrain intentionally disabled — conflicts with Google 3D Tiles at high zoom.
       // Google Photorealistic 3D Tiles provide their own terrain/elevation.
@@ -192,6 +214,14 @@ async function init() {
 
     // Initialize the style manager (post-processing, HUD, locations, share links)
     const styleManager = new StyleManager(viewer, { mapStackController });
+
+    if (deviceProfile.disablePostProcess) {
+      // After the StyleManager registered its stages, so they all exist to be
+      // switched off.
+      const disabledStages = disableAllPostProcess(viewer);
+      console.info(`[mobile] post-process disabled (${disabledStages} stages)`);
+    }
+
     // The previous multi-canvas weather compositor remains disabled. Cockpit
     // clouds use a separate, capped low-resolution GPU pass that never attaches
     // Cesium fog or post-process stages and is fully stopped in map mode.
@@ -281,6 +311,11 @@ async function init() {
     // toggle finds it live.
     installScopeMask(viewer);
 
+    if (deviceProfile.disablePostProcess) {
+      // One more full-screen pass; the mobile profile skips it.
+      setScopeMaskEnabled(false);
+    }
+
     // The follow camera recomputes the tracked target's dead-reckon position
     // every frame — tracking anything is a per-frame animation. (perf wave 2)
     viewer.trackedEntityChanged.addEventListener(() => {
@@ -324,6 +359,10 @@ async function init() {
       getRenderGovernorDiagnostics,
       requestRender: governorRequestRender,
     };
+
+    // Only with ?gevFlags=diag. Last, so the readout sees the final viewer
+    // state.
+    installDiagOverlay(viewer);
     window.__godsEyeView.voiceCommands = initGevVoiceCommands({ viewer, styleManager, dataManager, sceneDirector, annotations });
 
   } catch (error) {

--- a/src/mobileProfile.js
+++ b/src/mobileProfile.js
@@ -1,0 +1,226 @@
+/**
+ * Mobile profile: lighter rendering on phones and small tablets.
+ *
+ * The desktop defaults are tuned for a laptop GPU: a preserved drawing
+ * buffer (needed for recording), an unbounded photoreal tile cache and
+ * several full-screen post-process passes, all at the device pixel ratio.
+ * A phone pays for every one of them: the post-process passes re-shade the
+ * whole frame, the 3x device pixel ratio triples the pixels, and the tile
+ * cache grows until iOS WebKit reloads the tab (around 1 to 1.5 GB of WebGL
+ * memory).
+ *
+ * On a handheld this module trades some image quality for a globe that keeps
+ * running: CSS-pixel resolution, a bounded tile cache with a coarser level of
+ * detail, and no post-process passes. MSAA stays at 4x: at CSS-pixel
+ * resolution it is cheap, and edges need it more there. Desktop is untouched.
+ *
+ * `?gevMobile=1` / `?gevMobile=0` force the profile on or off (a tablet user
+ * who wants desktop quality, or a desktop test of the phone path).
+ * `?gevFlags=diag` paints a small on-screen readout of the GPU, browser and
+ * canvas sizes, so a phone user can report a rendering problem without a
+ * console. See docs/KNOWN-ISSUES.md.
+ *
+ * @module mobileProfile
+ */
+
+/**
+ * True on touch-first devices whose shorter screen side is under 900 px.
+ * @returns {boolean}
+ */
+export function isMobileDevice() {
+  // Tests import this module under Node, where there is no window.
+  if (typeof window === 'undefined') return false;
+
+  // A manual override in the URL wins over detection.
+  const forced = /[?&#]gevMobile=(1|0)/.exec(window.location.href);
+  if (forced) return forced[1] === '1';
+
+  // Finger rather than mouse: the primary pointer is imprecise. maxTouchPoints
+  // is the fallback for browsers without the media query.
+  const coarse = window.matchMedia?.('(pointer: coarse)')?.matches === true;
+  const touch = (navigator.maxTouchPoints || 0) > 0;
+
+  // The shorter side, so orientation does not matter. 900 px keeps phones and
+  // regular iPads in; a 12.9 inch iPad Pro (1024 px) stays on desktop.
+  const small = Math.min(window.screen?.width || 9999, window.screen?.height || 9999) < 900;
+
+  // A touch laptop is not a phone; a small touch screen is.
+  return (coarse || touch) && small;
+}
+
+/** Settings applied on handhelds. Each one is a fill-rate or memory saving. */
+export const MOBILE_PROFILE = Object.freeze({
+  // Kept at the desktop value: at CSS-pixel resolution 4x MSAA is cheap, and
+  // edges need it more there.
+  msaaSamples: 4,
+  // Only recording needs the buffer preserved, and it blocks the fast swap.
+  preserveDrawingBuffer: false,
+  // Photoreal tiles kept in memory. Unbounded upstream, which is what makes
+  // iOS reload the tab; 256 MB plus 64 MB of overflow before Cesium refuses
+  // new tiles keeps a phone well under its WebGL ceiling.
+  tilesetCacheBytes: 256 * 1024 * 1024,
+  tilesetMaximumCacheOverflowBytes: 64 * 1024 * 1024,
+  // Coarser level of detail than Cesium's default of 16: fewer, larger tiles
+  // per view.
+  tilesetMaximumScreenSpaceError: 24,
+  // Scope mask, sharpen, bloom and the style shaders each re-shade the whole
+  // frame.
+  disablePostProcess: true,
+});
+
+/** The upstream desktop defaults, spelled out so the two can be compared. */
+export const DESKTOP_PROFILE = Object.freeze({
+  // The upstream viewer options, unchanged.
+  msaaSamples: 4,
+  preserveDrawingBuffer: true,
+  // null means "leave Cesium's default alone".
+  tilesetCacheBytes: null,
+  tilesetMaximumCacheOverflowBytes: null,
+  tilesetMaximumScreenSpaceError: null,
+  // Every visual style and full-screen pass stays available.
+  disablePostProcess: false,
+});
+
+/**
+ * The profile for this device, decided once per page load.
+ * @returns {typeof MOBILE_PROFILE | typeof DESKTOP_PROFILE}
+ */
+export function activeProfile() {
+  return isMobileDevice() ? MOBILE_PROFILE : DESKTOP_PROFILE;
+}
+
+/**
+ * Apply the profile's tile limits to a Cesium3DTileset. Each limit is written
+ * only when the profile sets it, so the desktop profile (all null) leaves
+ * Cesium's own defaults exactly as they were.
+ * @param {import('cesium').Cesium3DTileset} tileset - The photoreal tileset.
+ * @param {object} [profile] - MOBILE_PROFILE or DESKTOP_PROFILE (active one).
+ */
+export function applyTilesetProfile(tileset, profile = activeProfile()) {
+  // The tileset is null when Google 3D Tiles failed to load and the app fell
+  // back to the plain globe.
+  if (!tileset) return;
+
+  // `!= null` on purpose: 0 would be a legal value, only null means "not set".
+  // cacheBytes is the memory Cesium keeps loaded tiles in before it starts
+  // unloading the ones outside the view.
+  if (profile.tilesetCacheBytes != null) tileset.cacheBytes = profile.tilesetCacheBytes;
+
+  // How far over cacheBytes the cache may grow while tiles needed for the
+  // current view are still arriving, before Cesium refuses new ones.
+  if (profile.tilesetMaximumCacheOverflowBytes != null) {
+    tileset.maximumCacheOverflowBytes = profile.tilesetMaximumCacheOverflowBytes;
+  }
+
+  // Screen-space error in pixels that a tile may show before Cesium refines
+  // it into its children. Higher means coarser tiles and fewer requests.
+  if (profile.tilesetMaximumScreenSpaceError != null) {
+    tileset.maximumScreenSpaceError = profile.tilesetMaximumScreenSpaceError;
+  }
+}
+
+/**
+ * Disable every post-process stage (style shaders, sharpen, bloom, FXAA).
+ * @param {import('cesium').Viewer} viewer
+ * @returns {number} stages that were enabled and got switched off
+ */
+export function disableAllPostProcess(viewer) {
+  // Cesium's PostProcessStageCollection; absent on the bare viewers used in
+  // tests.
+  const stages = viewer?.scene?.postProcessStages;
+  if (!stages) return 0;
+
+  // Counts only stages that were actually on, so the console line is honest.
+  let disabledCount = 0;
+
+  // The collection is not iterable; it exposes length and get(index).
+  for (let i = 0; i < stages.length; i += 1) {
+    const stage = stages.get(i);
+    if (!stage?.enabled) continue;
+    stage.enabled = false;
+    disabledCount += 1;
+  }
+
+  // The built-in stages live outside the indexed list.
+  if (stages.fxaa) stages.fxaa.enabled = false;
+  if (stages.bloom) stages.bloom.enabled = false;
+
+  return disabledCount;
+}
+
+/**
+ * True when `?gevFlags=diag` is in the URL (query or hash).
+ * @param {string} [href]
+ * @returns {boolean}
+ */
+export function wantsDiagOverlay(href = (typeof window !== 'undefined' ? window.location.href : '')) {
+  // Query or hash: share links keep their state in the hash.
+  const match = /[?&#]gevFlags=([a-z0-9,_-]+)/i.exec(href || '');
+  if (!match) return false;
+
+  return match[1].toLowerCase().split(',').includes('diag');
+}
+
+/**
+ * On-screen readout for reporting rendering problems from a phone: browser,
+ * GPU, device pixel ratio, canvas vs. drawing-buffer size, GL limits and
+ * which profile is active. Refreshes every 2 s. Only installed with
+ * `?gevFlags=diag`.
+ * @param {import('cesium').Viewer} viewer
+ * @returns {HTMLElement|null}
+ */
+export function installDiagOverlay(viewer) {
+  if (!wantsDiagOverlay() || typeof document === 'undefined') return null;
+
+  // A <pre> keeps the line breaks without any CSS of its own.
+  const readout = document.createElement('pre');
+  readout.id = 'gev-diag';
+  readout.style.cssText = 'position:fixed;left:6px;top:6px;z-index:99999;margin:0;padding:6px 8px;background:rgba(0,0,0,.8);color:#7CFC00;font:11px/1.35 monospace;white-space:pre-wrap;max-width:92vw;pointer-events:none';
+  document.body.appendChild(readout);
+
+  // Cesium's own context first: asking the canvas would create a second one.
+  const gl = viewer?.scene?.context?._gl || viewer?.canvas?.getContext('webgl2');
+  // The unmasked GPU name; null where the browser hides it.
+  const rendererInfo = gl?.getExtension('WEBGL_debug_renderer_info');
+
+  /**
+   * Read one GL limit by name, or '?' when the context or the constant is
+   * missing, so one unsupported query never blanks the whole readout.
+   * @param {string} name - A WebGL constant name such as 'MAX_TEXTURE_SIZE'.
+   * @returns {number|number[]|string}
+   */
+  function glParameter(name) {
+    try {
+      return gl.getParameter(gl[name]);
+    } catch {
+      return '?';
+    }
+  }
+
+  /**
+   * Rewrite the readout from live values. Cheap enough to run on a timer:
+   * eight template strings and one textContent assignment.
+   */
+  function repaint() {
+    // CSS size against attribute size on the canvas shows any DPR mismatch.
+    const canvas = viewer?.canvas;
+    const scene = viewer?.scene;
+
+    readout.textContent = [
+      `UA ${navigator.userAgent.slice(0, 90)}`,
+      `renderer ${rendererInfo ? gl.getParameter(rendererInfo.UNMASKED_RENDERER_WEBGL) : '?'}`,
+      `dpr ${window.devicePixelRatio} inner ${window.innerWidth}x${window.innerHeight} screen ${screen.width}x${screen.height}`,
+      `canvas css ${canvas?.clientWidth}x${canvas?.clientHeight} attr ${canvas?.width}x${canvas?.height} buffer ${gl?.drawingBufferWidth}x${gl?.drawingBufferHeight}`,
+      `resolutionScale ${viewer?.resolutionScale} recommended ${viewer?.useBrowserRecommendedResolution} msaa ${scene?.msaaSamples}`,
+      `MAX_TEXTURE ${glParameter('MAX_TEXTURE_SIZE')} MAX_RENDERBUFFER ${glParameter('MAX_RENDERBUFFER_SIZE')} MAX_VIEWPORT ${glParameter('MAX_VIEWPORT_DIMS')}`,
+      `mobileProfile ${Boolean(window.__gevMobile)} stages ${scene?.postProcessStages?.length}`,
+      `webgl2 ${typeof WebGL2RenderingContext !== 'undefined' && gl instanceof WebGL2RenderingContext}`,
+    ].join('\n');
+  }
+
+  // Sizes change on rotate and on the first resize; 2 s is plenty for a
+  // screenshot.
+  repaint();
+  setInterval(repaint, 2000);
+  return readout;
+}

--- a/src/mobileProfile.test.mjs
+++ b/src/mobileProfile.test.mjs
@@ -1,0 +1,72 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  MOBILE_PROFILE,
+  DESKTOP_PROFILE,
+  applyTilesetProfile,
+  disableAllPostProcess,
+  wantsDiagOverlay,
+} from './mobileProfile.js';
+
+// The desktop values are the upstream ones; if someone changes them in main.js
+// this test is the reminder to change them here too.
+test('profiles: mobile is lighter than the desktop defaults', () => {
+  assert.equal(DESKTOP_PROFILE.msaaSamples, 4);
+  assert.equal(DESKTOP_PROFILE.preserveDrawingBuffer, true);
+  assert.equal(DESKTOP_PROFILE.disablePostProcess, false);
+  assert.equal(MOBILE_PROFILE.msaaSamples, DESKTOP_PROFILE.msaaSamples, 'MSAA is kept on phones');
+  assert.equal(MOBILE_PROFILE.preserveDrawingBuffer, false);
+  assert.ok(MOBILE_PROFILE.tilesetCacheBytes > 0);
+  assert.equal(MOBILE_PROFILE.disablePostProcess, true);
+});
+
+// A null limit means "leave Cesium's default", so the desktop profile must
+// not write anything.
+test('applyTilesetProfile: desktop leaves the tileset untouched, mobile bounds it', () => {
+  const tileset = { cacheBytes: 1, maximumCacheOverflowBytes: 2, maximumScreenSpaceError: 16 };
+
+  applyTilesetProfile(tileset, DESKTOP_PROFILE);
+  assert.deepEqual(tileset, { cacheBytes: 1, maximumCacheOverflowBytes: 2, maximumScreenSpaceError: 16 });
+
+  applyTilesetProfile(tileset, MOBILE_PROFILE);
+  assert.equal(tileset.cacheBytes, MOBILE_PROFILE.tilesetCacheBytes);
+  assert.equal(tileset.maximumCacheOverflowBytes, MOBILE_PROFILE.tilesetMaximumCacheOverflowBytes);
+  assert.equal(tileset.maximumScreenSpaceError, MOBILE_PROFILE.tilesetMaximumScreenSpaceError);
+
+  assert.doesNotThrow(() => applyTilesetProfile(null, MOBILE_PROFILE));
+});
+
+// No Cesium here: the double only mimics the shape of
+// PostProcessStageCollection that the function relies on (length, get(index),
+// and the built-in fxaa and bloom stages that live outside the indexed list).
+test('disableAllPostProcess: switches every enabled stage off and reports the count', () => {
+  const stages = [{ enabled: true }, { enabled: false }, { enabled: true }];
+  const viewer = {
+    scene: {
+      postProcessStages: {
+        length: stages.length,
+        get: (index) => stages[index],
+        fxaa: { enabled: true },
+        bloom: { enabled: true },
+      },
+    },
+  };
+
+  // Two were on, one was already off: the count reports only what changed.
+  assert.equal(disableAllPostProcess(viewer), 2);
+  assert.ok(stages.every((stage) => !stage.enabled));
+  assert.equal(viewer.scene.postProcessStages.fxaa.enabled, false);
+  assert.equal(viewer.scene.postProcessStages.bloom.enabled, false);
+
+  assert.equal(disableAllPostProcess({}), 0);
+});
+
+// Share links keep their state in the hash, so the flag has to be found there
+// too.
+test('wantsDiagOverlay: only with ?gevFlags=diag, in query or hash', () => {
+  assert.equal(wantsDiagOverlay('https://x/?gevFlags=diag'), true);
+  assert.equal(wantsDiagOverlay('https://x/#v=2&gevFlags=Diag'), true);
+  assert.equal(wantsDiagOverlay('https://x/?gevFlags=other'), false);
+  assert.equal(wantsDiagOverlay('https://x/'), false);
+  assert.equal(wantsDiagOverlay(''), false);
+});


### PR DESCRIPTION
Hi Bilawal, this PR makes the globe render lighter on phones, automatically. **Desktop does not change at all.**

First, so nobody sends the same thing twice: I went through the open PRs and issues before writing this and nothing covers phones. The closest are #2 (the top bar responsive) and #72 (the desktop perf items from #8). #72 also drops `preserveDrawingBuffer`, so the two touch the same line in `main.js`; I can rebase on whichever lands first.

The short version of why: the desktop settings ask the GPU to draw every frame several times over (the 3x pixel density of a phone screen, and each visual style, sharpen, bloom and scope mask being one more full-screen pass), and the photoreal tile cache has no limit. A laptop GPU does not care. A phone GPU cannot keep up, and on iOS the tab reloads itself once WebGL memory goes past **1 to 1.5 GB**.

**What changes on a phone:** the viewer now starts with no preserved drawing buffer (only recording needs it), the screen's own resolution instead of 3x, a 256 MB tile cache with a bit less detail (`maximumScreenSpaceError` 24), and the post-process passes off. The picture is slightly softer and the globe keeps running. **Anti-aliasing stays at 4x** on purpose: at the screen's own resolution it is cheap, and edges need it more there. All of it is one small file, `src/mobileProfile.js`, with the desktop and phone values side by side.

**How it decides:** touch screen and the shorter side under **900 px**. That is the whole rule, on purpose. It means a regular iPad counts as a phone here and gets the lighter profile; a 12.9 inch iPad Pro does not. Nobody has to do anything, but there are two manual switches, documented in `docs/KNOWN-ISSUES.md` under "Phones and small tablets": `?gevMobile=0` if a tablet user wants desktop quality, and `?gevMobile=1` to try the phone path on a desktop.

**One more small thing** in the same file: `?gevFlags=diag` paints a green box with browser, GPU, pixel density and canvas sizes. When someone says "it looks wrong on my phone" you can ask for a screenshot of that box instead of guessing. Without the flag nothing is added to the page. I needed exactly that this week with a Galaxy S24 and Edge; screenshots and the story in the comment below.

**Verified** on an iPhone (Edge iOS, WebKit) and a Galaxy S24 (Chrome), both load and render with the profile active. Desktop checked with the profile forced off: stages, cache and resolution exactly as before. `npm test` (4 new tests in `src/mobileProfile.test.mjs`), `npm run build` and `npm run test:track` are green. `CHANGELOG.md` and `docs/CURRENT-STATE.md` updated.

To be clear, this **does not touch the HUD layout**, which is still a desktop layout on a narrow screen.

And honestly, thanks for opening this. I have spent more hours than I should this week flying over my own island with it, and it is the first map app in a long time that made me want to work on it. Have a good one!
