### PR TITLE
Add Claude Code launch config for local dev preview

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "gods-eye-view",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev", "--", "--host", "localhost", "--port", "4173"],
+      "port": 4173
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds `.claude/launch.json`, a small config file used by Claude Code's browser-preview tooling to start the Vite dev server (`npm run dev -- --host localhost --port 4173`) when previewing this project.

## Test plan
- N/A — config-only change, no application code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)