### PR TITLE
chore: add .gitattributes so 25 tests stop failing on Windows clones

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,20 @@
+# Check every text file out with LF on every platform.
+#
+# 44 unit test files read repository source with readFileSync and match it
+# against multi-line regexes (src/scenes/director.test.mjs,
+# src/cockpitMarkup.test.mjs, src/firstRunExperience.test.mjs, ...). Those
+# patterns anchor on \n, so under Git's default core.autocrlf=true on Windows
+# the sources check out with CRLF, every anchored pattern misses, and `npm test`
+# fails 25 checks on an unmodified clone. Normalizing here keeps the working
+# tree byte-identical on macOS, Linux, and Windows.
+* text=auto eol=lf
+
+# Shell launchers must stay LF to run at all.
+*.sh text eol=lf
+
+# Assets Git must never rewrite.
+*.gif binary
+*.png binary
+*.glb binary
+*.wav binary
+*.pbf binary


### PR DESCRIPTION
`npm test` fails **25 checks on an unmodified `main`** for anyone who clones on Windows. The cause isn't any of those tests — it's that the repo has no `.gitattributes`.

## What happens

Git's default on Windows is `core.autocrlf=true`, so every text file checks out with CRLF. 44 test files read repository source with `readFileSync` and match it against multi-line regexes anchored on `\n`:

```js
// src/scenes/director.test.mjs:486
const source = fs.readFileSync(new URL('../ui.js', import.meta.url), 'utf8');
const method = source.match(/\n {2}async applyVisualState\([\s\S]*?\n {2}\}\n/);
assert.ok(method, 'applyVisualState is missing from ui.js');
```

With CRLF the `\n {2}` never matches, and the assertion reports the source as *missing* rather than as differently-terminated. 158 `readFileSync` call sites across the suite share this exposure.

## Reproduce

```bash
git clone https://github.com/bilawalsidhu/gods-eye-view.git   # core.autocrlf=true, the Windows default
cd gods-eye-view && npm install
npm test
```

25 failures across 13 files:

```
src/cameraHandoff.test.mjs          src/data/militaryInstallations.test.mjs
src/cockpitMarkup.test.mjs          src/data/trackedModelRegime.test.mjs
src/data/cctv.test.mjs              src/firstRunExperience.test.mjs
src/data/firmsInteraction.test.mjs  src/loadingFeedback.test.mjs
src/data/militaryAwareness.test.mjs src/locationReadouts.test.mjs
src/overlays/worldOverlay.test.mjs  src/reasonableDefaults.test.mjs
src/scenes/director.test.mjs
```

Confirmed on Node 24.14.0 (the version CONTRIBUTING pins) — not a Node-version artifact. `git config core.autocrlf false` plus a re-checkout makes all 25 pass, which isolates line endings as the only variable.

## The fix

One file. `* text=auto eol=lf` pins the working tree to LF on every platform, with `*.sh` explicit and the binary assets (`.gif`, `.png`, `.glb`, `.wav`, `.pbf`) marked so Git never rewrites them.

I put the reasoning in the file itself, since the next person to hit this will be reading `.gitattributes`, not this PR.

## Verification

**No content churn.** The index is already LF everywhere, so this rewrites nothing in history:

```
$ git add --renormalize .
$ git diff --cached --stat
(empty)
```

**It actually fixes the failures.** Cloned this branch with the Windows default explicitly forced:

```
$ git clone -c core.autocrlf=true <branch> gev-verify
$ cd gev-verify && npm test
ℹ tests 2587
ℹ pass 2587
ℹ fail 0
```

Zero CRLF files in the tracked tree after that clone. Before the change, the same clone gave 2562 pass / 25 fail.

`npm run build` is green. I could not run `npm run test:track` or the `qa:*` gates — those need a Google Maps key with the Map Tiles API enabled, which I don't have; this change touches no runtime code.

## Note for existing Windows clones

`.gitattributes` fixes new clones. Anyone who already cloned needs one refresh:

```bash
git rm --cached -rf . && git reset --hard
```

Happy to add that to CONTRIBUTING if you'd like it documented.
