### PR TITLE
fix(cctv): cap the buffered snapshot body in the frame proxy (#28)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,10 @@ represent previously published GitHub Releases.
 
 ### Security
 
+- The CCTV frame proxy caps one buffered snapshot at 16 MB while it reads. A
+  configured source that declares or streams a larger body is cancelled and
+  treated as an ordinary upstream miss, so the Street View and synthetic
+  fallbacks still run.
 - Production transitive dependencies resolve to patched DOMPurify and
   protobufjs releases without changing the Cesium version or application APIs.
 - Production dependency audit reports no known advisories; remaining audit

--- a/src/data/cctvProxy.test.mjs
+++ b/src/data/cctvProxy.test.mjs
@@ -2,8 +2,26 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import {
   CCTV_FRAME_FETCH_TIMEOUT_MS,
+  CCTV_FRAME_MAX_BODY_BYTES,
   fetchCctvImageFromUpstream,
 } from '../../vite.config.js';
+
+/** A body that arrives in chunks and never declares a Content-Length. */
+function chunkedImageResponse(chunkBytes, chunkCount, { onChunk = () => {}, onCancel = () => {} } = {}) {
+  const stream = new ReadableStream({
+    async pull(controller) {
+      if (chunkCount <= 0) {
+        controller.close();
+        return;
+      }
+      chunkCount -= 1;
+      onChunk();
+      controller.enqueue(new Uint8Array(chunkBytes));
+    },
+    cancel: onCancel,
+  });
+  return new Response(stream, { status: 200, headers: { 'Content-Type': 'image/jpeg' } });
+}
 
 test('CCTV upstream frame fetch supplies a bounded abort signal', async () => {
   let observedSignal = null;
@@ -35,4 +53,66 @@ test('CCTV upstream frame fetch returns a valid image response', async () => {
   assert.equal(result?.ok, true);
   assert.equal(result?.contentType, 'image/jpeg');
   assert.deepEqual(result?.body, Buffer.from([1, 2, 3]));
+});
+
+test('CCTV upstream frame fetch rejects a declared oversize body without draining it', async () => {
+  const chunkBytes = 64 * 1024;
+  let pulled = 0;
+  let cancelled = false;
+  const result = await fetchCctvImageFromUpstream('https://example.com/frame.jpg', {
+    timeoutMs: 1000,
+    maxBytes: chunkBytes * 4,
+    fetchImpl: async () => {
+      const response = chunkedImageResponse(chunkBytes, 64, {
+        onChunk: () => { pulled += 1; },
+        onCancel: () => { cancelled = true; },
+      });
+      response.headers.set('Content-Length', String(chunkBytes * 64));
+      return response;
+    },
+  });
+
+  // Assert on the byte count, not the object: a regressed proxy returns a
+  // multi-megabyte Buffer here, and diffing one into the failure report is
+  // slower than the check it is reporting on.
+  assert.equal(result?.body?.length ?? null, null, 'a declared oversize snapshot is a miss, not a buffered body');
+  assert.equal(cancelled, true, 'the declared cap is enforced by cancelling, not reading');
+  // Only the stream's own one-chunk prefetch may have run; the proxy pulls none.
+  assert.ok(pulled <= 1, `declared cap short-circuits the read, pulled ${pulled} chunks`);
+});
+
+test('CCTV upstream frame fetch aborts an undeclared body once it crosses the cap', async () => {
+  const chunkBytes = 64 * 1024;
+  let pulled = 0;
+  let cancelled = false;
+  const result = await fetchCctvImageFromUpstream('https://example.com/frame.jpg', {
+    timeoutMs: 1000,
+    maxBytes: chunkBytes * 4,
+    // Sixty-four chunks are offered with no Content-Length; a proxy that
+    // buffers first would take all of them.
+    fetchImpl: async () => chunkedImageResponse(chunkBytes, 64, {
+      onChunk: () => { pulled += 1; },
+      onCancel: () => { cancelled = true; },
+    }),
+  });
+
+  assert.equal(result?.body?.length ?? null, null, 'a chunked body over the cap is a miss');
+  // Four chunks fit, the fifth crosses the cap, and one more sits in the
+  // stream's prefetch queue — nothing past that is ever pulled.
+  assert.ok(pulled <= 6, `stopped reading at the cap, pulled ${pulled} chunks`);
+  assert.equal(cancelled, true, 'the upstream stream is cancelled, not drained');
+});
+
+test('CCTV upstream frame fetch still returns a chunked body under the cap', async () => {
+  const chunkBytes = 1024;
+  const result = await fetchCctvImageFromUpstream('https://example.com/frame.jpg', {
+    timeoutMs: 1000,
+    maxBytes: chunkBytes * 8,
+    fetchImpl: async () => chunkedImageResponse(chunkBytes, 3),
+  });
+
+  assert.equal(result?.ok, true);
+  assert.equal(result?.body?.length, chunkBytes * 3, 'every chunk is reassembled in order');
+  assert.ok(CCTV_FRAME_MAX_BODY_BYTES > 0 && CCTV_FRAME_MAX_BODY_BYTES <= 64 * 1024 * 1024,
+    'the frame cap must be at or under the media route cap');
 });

--- a/vite.config.js
+++ b/vite.config.js
@@ -3501,6 +3501,11 @@ const CCTV_SOURCE_FETCH_TIMEOUT_MS = 15 * 1000;
  * client refresh cadence. A bounded miss can fall through to Street View or
  * the synthetic frame instead of leaving the browser preview pending. */
 export const CCTV_FRAME_FETCH_TIMEOUT_MS = 8 * 1000;
+/** Hard ceiling on one buffered snapshot frame. Public CCTV stills run well
+ * under a megabyte; 16 MB clears even a 4K PNG while keeping a hostile or
+ * misconfigured source from buffering an unbounded body into the proxy inside
+ * the 8-second window. Live media keeps its own, larger streamed cap. */
+export const CCTV_FRAME_MAX_BODY_BYTES = 16 * 1024 * 1024;
 /** @type {Array<object>} Cached merged + normalized CCTV source list. */
 let _cctvSourceCache = [];
 /** @type {number} Epoch-ms when the source cache was last refreshed. */
@@ -4367,6 +4372,39 @@ async function readCappedResponseText(upstream, maxBytes) {
   return { tooLarge: false, text };
 }
 
+/**
+ * Binary counterpart of readCappedResponseText: buffer a fetch Response body
+ * while enforcing a hard byte cap during the read. A declared Content-Length
+ * over the cap is refused before a single body byte is pulled; a missing or
+ * lying one is caught as chunks arrive and the stream is cancelled. Returns
+ * null on overflow so callers can treat oversize like any other upstream miss.
+ * @param {Response} upstream - fetch() response.
+ * @param {number} maxBytes - hard ceiling on body bytes.
+ * @returns {Promise<Buffer|null>} Buffered body, or null once the cap is crossed.
+ */
+async function readCappedResponseBytes(upstream, maxBytes) {
+  const declared = Number(upstream.headers.get('content-length'));
+  if (Number.isFinite(declared) && declared > maxBytes) {
+    try { await upstream.body?.cancel(); } catch { /* no-op */ }
+    return null;
+  }
+  if (!upstream.body || typeof upstream.body[Symbol.asyncIterator] !== 'function') {
+    const buffered = Buffer.from(await upstream.arrayBuffer());
+    return buffered.length > maxBytes ? null : buffered;
+  }
+  const chunks = [];
+  let total = 0;
+  for await (const chunk of upstream.body) {
+    total += chunk.length;
+    if (total > maxBytes) {
+      try { await upstream.body.cancel(); } catch { /* no-op */ }
+      return null;
+    }
+    chunks.push(Buffer.from(chunk.buffer, chunk.byteOffset, chunk.byteLength));
+  }
+  return Buffer.concat(chunks, total);
+}
+
 async function proxyMediaResponse(res, upstream, { sourceHeader = 'upstream' } = {}) {
   const contentType = upstream.headers.get('content-type') || 'application/octet-stream';
   const cacheControl = upstream.headers.get('cache-control') || 'no-store';
@@ -4415,15 +4453,21 @@ async function proxyMediaResponse(res, upstream, { sourceHeader = 'upstream' } =
  * continue through the Street View and synthetic fallback chain. `fetchImpl`
  * and `timeoutMs` are injectable only to keep the timeout contract unit-testable.
  *
+ * The body is capped while it is read, so a source that turns hostile (or is
+ * simply misconfigured) can't buffer an unbounded frame into the proxy inside
+ * the timeout window. An oversize body is a miss like any other.
+ *
  * @param {string} url - Server-registered upstream image URL.
  * @param {object} [options]
  * @param {typeof fetch} [options.fetchImpl=fetch] - Fetch implementation.
  * @param {number} [options.timeoutMs=CCTV_FRAME_FETCH_TIMEOUT_MS] - Abort timeout.
+ * @param {number} [options.maxBytes=CCTV_FRAME_MAX_BODY_BYTES] - Hard body cap.
  * @returns {Promise<{ok:true,body:Buffer,contentType:string}|null>}
  */
 export async function fetchCctvImageFromUpstream(url, {
   fetchImpl = fetch,
   timeoutMs = CCTV_FRAME_FETCH_TIMEOUT_MS,
+  maxBytes = CCTV_FRAME_MAX_BODY_BYTES,
 } = {}) {
   if (!url || !/^https?:\/\//i.test(url)) return null;
   const controller = new AbortController();
@@ -4437,11 +4481,9 @@ export async function fetchCctvImageFromUpstream(url, {
     });
     const contentType = upstream.headers.get('content-type') || '';
     if (!upstream.ok || !contentType.startsWith('image/')) return null;
-    return {
-      ok: true,
-      body: Buffer.from(await upstream.arrayBuffer()),
-      contentType,
-    };
+    const body = await readCappedResponseBytes(upstream, maxBytes);
+    if (!body) return null;
+    return { ok: true, body, contentType };
   } catch {
     return null;
   } finally {


### PR DESCRIPTION
Closes #28.

`fetchCctvImageFromUpstream` validated content-type and then buffered the whole upstream body:

```js
if (!upstream.ok || !contentType.startsWith('image/')) return null;
return { ok: true, body: Buffer.from(await upstream.arrayBuffer()), contentType };
```

There's no cap on that read. SECURITY.md says "high-volume or attacker-influenced upstream responses are capped where that boundary matters" — this path is the gap.

## Confirming it's real, not theoretical

Before writing the fix I ran the current function against a source that streams 64 chunks of 64 KB with no `Content-Length`:

```
{ isNull: false, len: 4194304, pulled: 64, cancelled: false }
```

Every chunk pulled, whole body buffered, stream never cancelled. The 8s frame timeout doesn't help — it bounds *time*, not bytes, and a fast upstream can deliver a lot in 8 seconds. Frames refresh on a 10s cadence per active camera, so this repeats.

The catalogs are server-registered, so this needs a configured source to turn hostile or be misconfigured — not a client-supplied URL. That's why I'd call it hardening rather than an exploitable hole.

## The fix

`readCappedResponseBytes` — the binary counterpart of the existing `readCappedResponseText`, placed next to it and following the same shape:

- a declared `Content-Length` over the cap is refused **before a single body byte is pulled**
- a missing or lying one is caught as chunks arrive, and the stream is cancelled
- overflow returns `null`

`null` is what makes this cheap: the frame route already treats it as an upstream miss, so an oversize body falls through the existing Street View → synthetic-SVG chain instead of erroring. No new failure mode, no new response shape.

Cap is 16 MB (`CCTV_FRAME_MAX_BODY_BYTES`), exported so the test can pin it. Public CCTV stills run well under a megabyte; 16 MB clears even a 4K PNG. It sits under the media route's existing 64 MB declared cap, and the test asserts that ordering so the two can't drift.

## Tests

Four added to `src/data/cctvProxy.test.mjs`:

| Test | Pins |
|---|---|
| declared oversize | cancelled, ≤1 chunk pulled (the stream's own prefetch) |
| undeclared oversize | cancelled mid-stream, ≤6 of 64 chunks pulled |
| chunked under cap | every chunk reassembled, correct byte length |
| existing valid image | unchanged |

Verified red→green: with the old `arrayBuffer()` line restored, the two oversize tests fail; with the fix, all five pass.

One deliberate detail — the oversize tests assert on `result?.body?.length` rather than on `result` itself. Asserting object equality made a regressed run hang: `assert.equal` builds a diff of the 4 MB Buffer, which takes longer than the check it's reporting on. Comment in the test says so.

## Gates

```
npm test    ℹ tests 2590  ℹ pass 2590  ℹ fail 0
npm run build   ✓ built (only the pre-existing chunk-size warning, #40)
```

Node 24.14.0. I could not run `test:track` or the `qa:*` gates — they need a Google Maps key with the Map Tiles API enabled.

CHANGELOG entry added under Security. I left `docs/CURRENT-STATE.md` alone since no product-visible behavior changes — the fallback chain it documents is unchanged. Happy to add a note there if you'd rather it be recorded.
