### PR TITLE
fix(data): keep node:fs out of the browser-built data modules (#34)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@ of current runtime behavior, see [`docs/CURRENT-STATE.md`](docs/CURRENT-STATE.md
   outages and wait for measured photoreal-surface evidence before a 3D model
   takes over from its billboard.
 - Cockpit altitude uses aviation MSL data rather than Cesium render height.
+- The bundled Natural Earth region and neighborhood-polygon packs load through a
+  single import path in both the browser and `node:test`, so the production
+  build no longer externalizes `node:fs` for two browser data modules.
 
 ### Security
 

--- a/src/browserModuleBoundary.test.mjs
+++ b/src/browserModuleBoundary.test.mjs
@@ -1,0 +1,36 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SRC_ROOT = fileURLToPath(new URL('.', import.meta.url));
+
+/** Every browser-built module under src/ — the test files are Node-only. */
+function browserModules(directory = SRC_ROOT) {
+  const files = [];
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const absolute = path.join(directory, entry.name);
+    if (entry.isDirectory()) files.push(...browserModules(absolute));
+    else if (entry.isFile() && entry.name.endsWith('.js')) files.push(absolute);
+  }
+  return files.sort();
+}
+
+test('no browser-built module imports a Node core module', () => {
+  // Vite externalizes `node:*` for the browser and only WARNS, so a stray
+  // import survives the build and turns into a runtime failure the moment the
+  // guard around it is wrong. src/data/naturalEarthRegions.js and
+  // src/data/neighborhoodPolygons.js both carried one to read their bundled
+  // JSON packs under node:test; an import attribute serves both runtimes.
+  const offenders = [];
+  for (const file of browserModules()) {
+    const source = readFileSync(file, 'utf8');
+    // Static `from 'node:fs'` and dynamic `import('node:fs')`, quoted either way.
+    if (/\bfrom\s*['"]node:|\bimport\s*\(\s*(?:\/\*[^*]*\*\/\s*)?['"]node:/.test(source)) {
+      offenders.push(path.relative(SRC_ROOT, file).split(path.sep).join('/'));
+    }
+  }
+
+  assert.deepEqual(offenders, [], `Node core imports reached the browser build: ${offenders.join(', ')}`);
+});

--- a/src/data/naturalEarthRegions.js
+++ b/src/data/naturalEarthRegions.js
@@ -113,19 +113,13 @@ function suffixVariants(norm) {
 /** @type {Array|null} flat entry list for listRegions() */
 let _entries = null;
 
-const isNode = typeof process !== 'undefined' && !!process.versions?.node
-  && typeof window === 'undefined';
-
 async function loadPackFile(base) {
-  if (isNode) {
-    const { readFileSync } = await import(/* @vite-ignore */ 'node:fs');
-    const url = new URL(`./local_data/natural_earth/${base}.json`, import.meta.url);
-    return JSON.parse(readFileSync(url, 'utf8'));
-  }
-  // Vite bundles these JSON files as modules (same pattern as neighborhoodPolygons.js)
+  // Vite bundles these JSON files as modules; the import attribute is what Node
+  // needs to load the same files under node:test (same pattern as
+  // neighborhoodPolygons.js). One path, so no node: import reaches the browser.
   const mod = base === 'regions'
-    ? await import('./local_data/natural_earth/regions.json')
-    : await import('./local_data/natural_earth/marine.json');
+    ? await import('./local_data/natural_earth/regions.json', { with: { type: 'json' } })
+    : await import('./local_data/natural_earth/marine.json', { with: { type: 'json' } });
   return mod.default || mod;
 }
 

--- a/src/data/neighborhoodPolygons.js
+++ b/src/data/neighborhoodPolygons.js
@@ -14,11 +14,8 @@ import { createRetryableLoader } from './retryableLoad.js';
 
 // bbox = [west, south, east, north]; only load a city file when the point falls in its box.
 const CITY_FILES = [
-  { id: 'san-francisco', bbox: [-122.55, 37.70, -122.35, 37.84], loader: () => import('./local_data/neighborhoods/san-francisco.json') },
+  { id: 'san-francisco', bbox: [-122.55, 37.70, -122.35, 37.84], loader: () => import('./local_data/neighborhoods/san-francisco.json', { with: { type: 'json' } }) },
 ];
-
-const isNode = typeof process !== 'undefined' && !!process.versions?.node
-  && typeof window === 'undefined';
 
 /**
  * city id → memoized loader. Failures are NOT memoized: a transient
@@ -94,18 +91,10 @@ function cityLoader(city) {
   let loader = _cityLoaders.get(city.id);
   if (!loader) {
     loader = createRetryableLoader(async () => {
-      let fc;
-      if (isNode) {
-        // node:test path — plain dynamic JSON import needs an import attribute in Node,
-        // so read the file directly (same dual-path pattern as naturalEarthRegions.js).
-        const { readFileSync } = await import(/* @vite-ignore */ 'node:fs');
-        const url = new URL(`./local_data/neighborhoods/${city.id}.json`, import.meta.url);
-        fc = JSON.parse(readFileSync(url, 'utf8'));
-      } else {
-        // Vite bundles the JSON file as a module.
-        const mod = await city.loader();
-        fc = mod.default || mod;
-      }
+      // One path for both runtimes: Vite bundles the JSON as a module, and the
+      // import attribute is what Node needs to load the same file under node:test.
+      const mod = await city.loader();
+      const fc = mod.default || mod;
       return Array.isArray(fc.features) ? fc.features : [];
     });
     _cityLoaders.set(city.id, loader);


### PR DESCRIPTION
Closes #34.

`npm run build` emits these on every production build:

```
[plugin vite:resolve] Module "node:fs" has been externalized for browser
compatibility, imported by ".../src/data/naturalEarthRegions.js".
[plugin vite:resolve] Module "node:fs" has been externalized for browser
compatibility, imported by ".../src/data/neighborhoodPolygons.js".
```

Both modules carried the same dual path — the comment in `neighborhoodPolygons.js` explains why it was there:

```js
if (isNode) {
  // node:test path — plain dynamic JSON import needs an import attribute in Node,
  // so read the file directly (same dual-path pattern as naturalEarthRegions.js).
  const { readFileSync } = await import(/* @vite-ignore */ 'node:fs');
  ...
} else {
  const mod = await city.loader();   // Vite bundles the JSON file as a module
}
```

Vite only *warns* about externalizing `node:*`, so the import survives into the browser build and the boundary rests entirely on the `isNode` guard being right.

## The fix

The comment names the real constraint: Node needs an import attribute. So give it one, and the two paths collapse into one that both runtimes serve:

```js
loader: () => import('./local_data/neighborhoods/san-francisco.json', { with: { type: 'json' } })
```

Vite bundles the JSON exactly as before, Node loads the same file under `node:test`, and `isNode` plus `node:fs` disappear from both modules. Net −27/+22 lines in the two data modules.

## Verification

**Build.** Zero `externalized` warnings. The emitted JSON chunks are byte-identical to before — same content hashes:

```
regions-RPMKg9pq.js  marine-BJ61ZZ9E.js  san-francisco-B-TUYeaR.js
```

**Browser, not just build.** A build passing doesn't prove a dynamic import with an attribute still resolves at runtime, so I built a probe entry against these two modules and loaded it in headless Chrome:

```
{"neighborhoodName":"Chinatown","neighborhoodRingPoints":12,
 "saharaFound":true,"regionCount":1338}
```

Identical to the same calls under Node. No console errors (the one 404 was the probe page's own missing favicon). Probe was scaffolding and isn't in the diff.

**Regression guard.** `src/browserModuleBoundary.test.mjs` scans every non-test `.js` under `src/` for static and dynamic `node:` imports. Verified it fails on the pre-fix tree, naming exactly the two modules from the issue:

```
AssertionError: Node core imports reached the browser build:
  data/naturalEarthRegions.js, data/neighborhoodPolygons.js
```

This is the "build check that fails on Node core module externalization" the issue asks for, done as a unit test so it runs in `npm test` alongside the other source-shape checks (`cockpitMarkup.test.mjs`, `director.test.mjs`) rather than adding a build step.

## Gates

```
npm test    ℹ tests 2588  ℹ pass 2588  ℹ fail 0
npm run build   ✓ built, no externalization warnings
```

Node 24.14.0. `test:track` and the `qa:*` gates need a Google Maps key with the Map Tiles API enabled, which I don't have — but the browser probe above covers the runtime path these two modules own.

## One thing to check

`with { type: 'json' }` needs Node ≥ 20.10 and Rollup 4 / Vite 5+. `package.json` requires Node ≥ 24.14 and Vite ^6, so both are comfortably clear — flagging it in case you support an older toolchain somewhere I can't see.
