### PR TITLE
fix(firms): drop argument spread in fires.push — RangeError silently dropped 2 of 3 VIIRS sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,11 @@ of current runtime behavior, see [`docs/CURRENT-STATE.md`](docs/CURRENT-STATE.md
 
 ### Fixed
 
+- All three VIIRS sources now reach the Active Fires layer. Merging a source's
+  detections used argument spread, which exceeds the engine's argument limit on
+  the two largest sources and dropped them entirely — leaving roughly a third of
+  global detections while reporting each dropped source twice, once as
+  successful with its real count and once as failed.
 - A missing optional FIRMS key no longer turns the complete Environmental
   mission into `LOAD FAILED`. The FIRMS row still reports `KEY REQUIRED`, while
   earthquakes continue to load. Real lifecycle and fetch failures retain

--- a/vite.config.js
+++ b/vite.config.js
@@ -2039,7 +2039,10 @@ function firmsProxy() {
       try {
         const records = filterTrailing24h(await fetchSource(key, source), now);
         sources.push({ source, count: records.length, ok: true });
-        fires.push(...records);
+        // NOT fires.push(...records): spread passes each record as an argument,
+        // and a world/2 VIIRS pull exceeds V8's argument limit (~125k) at
+        // ~131k records — RangeError, and the whole source is silently dropped.
+        for (const record of records) fires.push(record);
       } catch (err) {
         console.warn(`[firms-proxy] ${source} fetch failed:`, err?.message || err);
         sources.push({ source, count: 0, ok: false });


### PR DESCRIPTION
## The bug

With a valid `FIRMS_MAP_KEY`, the Active Fires layer renders roughly a third of the detections it should. It looks healthy — there is no user-visible error, and `/api/firms` returns 200 with a plausible fire count.

The dev-server log tells the real story:

```
[firms-proxy] VIIRS_NOAA20_NRT fetch failed: Maximum call stack size exceeded
[firms-proxy] VIIRS_SNPP_NRT  fetch failed: Maximum call stack size exceeded
```

## Root cause

`refreshUpstream()` merged each source's records with `fires.push(...records)`. Spread passes every element as a separate function argument, and a `world/2` VIIRS pull is well past V8's argument limit (~125k):

| Source | Records | Outcome |
|---|---:|---|
| `VIIRS_NOAA20_NRT` | 130,863 | `RangeError` — dropped |
| `VIIRS_NOAA21_NRT` | 113,996 | under the limit — survived |
| `VIIRS_SNPP_NRT` | 132,325 | `RangeError` — dropped |

Two things made it hard to spot:

1. **NOAA21 is the only source small enough to survive**, so the layer always has data and never looks broken.
2. **The throw lands after `sources.push({ source, count: records.length, ok: true })`**, so the `catch` appends a *second* entry for the same source. Each failed source is reported twice in the payload — once `ok: true` with its real count, once `ok: false` — while its records are gone. The `sources` array looks like the fetch succeeded.

Since at least one source always succeeds, the `if (!sources.some((s) => s.ok))` guard never trips and the broken result is cached as a normal entry.

## The fix

```js
- fires.push(...records);
+ for (const record of records) fires.push(record);
```

No spread, no argument-count ceiling, same ordering and same allocation behavior.

## Result

| | before | after |
|---|---:|---:|
| Sources OK | 1 of 3 | **3 of 3** |
| Global fires (trailing 24 h) | 113,996 | **377,169** |

`sources` no longer contains duplicate entries.

## Verification

All three required checks, run against Node 26:

- `npm run build` — clean (exit 0)
- `npm test` — **2587 passed, 0 failed** (the 2 allocation microbenchmarks self-skip on Node 26: *"budgets are calibrated for Node 24"*)
- `npm run test:track` — **100 passed, 0 failed**, including *"no console errors across the FULL run"* and *"no HTTP 5xx responses across the FULL run"*

Also verified live against the real endpoint: `/api/firms` returns all three sources `ok: true`, and the dev-server log shows zero `Maximum call stack size exceeded` entries after the change.

## One consequence worth flagging

Carrying all three sources takes the `/api/firms` response from ~22 MB to ~74 MB. That is the correct amount of data — it was always meant to be there — but it is a real jump for anyone serving this beyond localhost. Happy to follow up with a separate PR if you would like the payload trimmed or paginated; I kept this one to the bug.

Found while running the project on a home server. Thanks for open-sourcing it.