### PR TITLE
feat: add Nix flake dev shell

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ output/
 .DS_Store
 .gstack/
 3d-models/
+.direnv/
+.envrc

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,8 @@ npm install
 ./scripts/dev-fresh.sh        # or: GOOGLE_MAPS_API_KEY="…" npm run dev
 ```
 
+**Nix users:** the repo ships a flake — `nix develop` drops you into a shell with the pinned Node 24 and a Chromium already wired up for the Puppeteer QA harnesses (no browser download, works on NixOS). With direnv, add a local `.envrc` containing `use flake`.
+
 You need a **Google Maps API key** with the Map Tiles API enabled (see the [README](README.md#-api-keys)). Most data layers work with no other accounts. On macOS the launcher pulls keys from the Keychain; on any platform you can pass them as env vars or use a `.env` (copy `.env.example`).
 
 Open `http://localhost:4173`. Before sending a PR run `npm run build`, `npm test`, and `npm run test:track` (dev server must be up) — **all three must stay green.**

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1787736819,
+        "narHash": "sha256-cV5xEJJK3BvhU8rEd4mC9UsmDi5qscv/kzGPhBRC5WA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9fbb54b33e91ee4ca368e35a78e0613c720600b3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,26 @@
+{
+  description = "God's Eye View dev shell: pinned Node.js 24 + Chromium for the Puppeteer QA harnesses";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let pkgs = nixpkgs.legacyPackages.${system};
+      in {
+        devShells.default = pkgs.mkShell {
+          packages = with pkgs; [
+            nodejs_24 # engines: >=24.14.0 <25 || >=26 <27 — Node 24 specifically,
+                      # because scripts/run-unit-tests.mjs gates its allocation
+                      # budgets on the Node 24 runtime
+            chromium  # browser for npm run test:track and scripts/qa-*.mjs
+          ];
+          # Point Puppeteer at the Nix chromium instead of its own downloaded
+          # Chrome, which is dynamically linked and cannot run on NixOS.
+          PUPPETEER_SKIP_DOWNLOAD = "1";
+          PUPPETEER_EXECUTABLE_PATH = "${pkgs.chromium}/bin/chromium";
+        };
+      });
+}


### PR DESCRIPTION
## What

A minimal Nix flake providing `devShells.default` with:

- **`nodejs_24`** (currently 24.19.0) — satisfies `engines: >=24.14.0 <25 || >=26 <27`, pinned to 24 specifically because `scripts/run-unit-tests.mjs` gates its allocation budgets on the Node 24 runtime.
- **`chromium`** wired to Puppeteer via `PUPPETEER_EXECUTABLE_PATH` + `PUPPETEER_SKIP_DOWNLOAD`, so `npm run test:track` and the `scripts/qa-*.mjs` harnesses run without downloading Chrome — which is dynamically linked and cannot run on NixOS at all.

Also: `.gitignore` entries for `.direnv/` and local `.envrc`, and a 2-line "Nix users" note in CONTRIBUTING.md. `flake.lock` is committed for reproducibility. No runtime behavior changes, so `docs/CURRENT-STATE.md` is untouched.

Nix users get the exact toolchain with `nix develop` (or `direnv allow` with a local `.envrc` containing `use flake`); everyone else is unaffected.

## Verification

All three gates run **inside `nix develop`** on x86_64-linux (NixOS-style setup under WSL2, no system Node/Chrome involvement):

- `nix flake check` — pass
- `node --version` → v24.19.0
- `npm run build` — built in 2.14s
- `npm test` — full suite green, including the Node-24-gated allocation benchmarks
- `npm run test:track` against the dev server on :4173 — **100 passed, 0 failed, 0 skipped**, no console errors, no HTTP 5xx, rendered through the Nix `chromium` (151.0.7922.173)

## Caveats

- Verified on `x86_64-linux` only. The flake targets all default systems via `flake-utils`, but darwin/aarch64 are untested (macOS users likely prefer the existing Keychain launcher anyway).
- `nixpkgs` follows `nixos-unstable`; if Node 24 ever drifts out of the engines range there, the lock pins a known-good revision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpbPP58wi1gj7KJoCvQzQp