### PR TITLE
fix(installations): derive a point from bounds when Overpass omits center

### DIFF
--- a/src/data/militaryInstallationData.js
+++ b/src/data/militaryInstallationData.js
@@ -54,7 +54,27 @@ function finiteLongitude(value) {
 function pointFrom(element) {
   const lat = Number(element?.lat ?? element?.center?.lat);
   const longitude = Number(element?.lon ?? element?.center?.lon);
-  return finiteLatitude(lat) && finiteLongitude(longitude) ? { latitude: lat, longitude } : null;
+  if (finiteLatitude(lat) && finiteLongitude(longitude)) return { latitude: lat, longitude };
+
+  // Bounds midpoint fallback (field test 2026-08-28, Warendorf: nothing drawn).
+  // The proxy asks for `out center tags geom`, but Overpass takes the LAST
+  // geometry mode only — `geom` wins and no `center` is ever emitted. Every
+  // way and relation therefore arrived point-less and was dropped here, so the
+  // layer rendered nodes and nothing else (San Diego: 149 of 228 kept, all the
+  // ways and relations gone; Warendorf has no nodes at all, hence an empty
+  // screen over a mapped Bundeswehr barracks). `bounds` accompanies exactly
+  // those elements — including relations, which carry no `geometry` — so it
+  // recovers all of them without touching the query or the footprint path.
+  const bounds = element?.bounds;
+  const south = Number(bounds?.minlat);
+  const west = Number(bounds?.minlon);
+  const north = Number(bounds?.maxlat);
+  const east = Number(bounds?.maxlon);
+  if (finiteLatitude(south) && finiteLatitude(north)
+      && finiteLongitude(west) && finiteLongitude(east)) {
+    return { latitude: (south + north) / 2, longitude: (west + east) / 2 };
+  }
+  return null;
 }
 
 function footprintFrom(element) {

--- a/src/data/militaryInstallationData.test.mjs
+++ b/src/data/militaryInstallationData.test.mjs
@@ -74,3 +74,54 @@ test('accepts only small non-dateline request bboxes', () => {
   assert.equal(isValidInstallationBoundingBox({ south: -1, west: 179, north: 1, east: -179 }), false);
   assert.equal(isValidInstallationBoundingBox({ south: -20, west: 0, north: 20, east: 1 }), false);
 });
+
+test('a way with only bounds is kept, at the midpoint of that box', () => {
+  // The proxy asks for `out center tags geom` and Overpass honours only the
+  // LAST geometry mode, so `center` is never emitted and every way/relation
+  // arrives carrying `bounds` instead. Dropping those rendered nodes and
+  // nothing else — an empty screen over mapped installations.
+  const result = normalizeMilitaryInstallations({ elements: [
+    { type: 'way', id: 92701457, bounds: { minlat: 51.94, minlon: 7.98, maxlat: 51.96, maxlon: 8.02 },
+      tags: { military: 'barracks', name: 'Sportschule der Bundeswehr' } },
+  ] }, '2026-08-28T00:00:00.000Z');
+
+  assert.equal(result.records.length, 1);
+  assert.equal(result.droppedCount, 0);
+  assert.equal(result.records[0].latitude, 51.95);
+  assert.equal(result.records[0].longitude, 8.00);
+});
+
+test('a relation with only bounds is kept — it carries no geometry at all', () => {
+  const result = normalizeMilitaryInstallations({ elements: [
+    { type: 'relation', id: 5, bounds: { minlat: -1, minlon: -2, maxlat: 1, maxlon: 2 },
+      tags: { landuse: 'military' } },
+  ] });
+  assert.equal(result.records.length, 1);
+  assert.equal(result.records[0].latitude, 0);
+  assert.equal(result.records[0].longitude, 0);
+});
+
+test('an explicit centre still wins over bounds', () => {
+  const result = normalizeMilitaryInstallations({ elements: [
+    { type: 'way', id: 6, center: { lat: 30.2, lon: -97.7 },
+      bounds: { minlat: 0, minlon: 0, maxlat: 60, maxlon: 60 },
+      tags: { military: 'airfield' } },
+  ] });
+  assert.equal(result.records[0].latitude, 30.2);
+  assert.equal(result.records[0].longitude, -97.7);
+});
+
+test('an out-of-range or incomplete bounds box is dropped, not averaged', () => {
+  const result = normalizeMilitaryInstallations({ elements: [
+    // latitude past the pole
+    { type: 'way', id: 1, bounds: { minlat: 80, minlon: 0, maxlat: 95, maxlon: 1 }, tags: { military: 'range' } },
+    // longitude past the antimeridian
+    { type: 'way', id: 2, bounds: { minlat: 0, minlon: 170, maxlat: 1, maxlon: 181 }, tags: { military: 'range' } },
+    // a half-filled box would average to a plausible-looking lie
+    { type: 'way', id: 3, bounds: { minlat: 10, maxlat: 12 }, tags: { military: 'range' } },
+    { type: 'way', id: 4, bounds: {}, tags: { military: 'range' } },
+    { type: 'way', id: 5, tags: { military: 'range' } },
+  ] });
+  assert.deepEqual(result.records, []);
+  assert.equal(result.droppedCount, 5);
+});


### PR DESCRIPTION
## The bug

`militaryInstallationsProxy` asks Overpass for `out center tags geom`. Overpass honours only the **last** geometry mode, so `geom` wins and `center` is never emitted. Every way and relation therefore arrives without `lat`/`lon`, and `pointFrom` drops it.

The layer has been rendering nodes and nothing else:

| Area | Kept |
|---|---|
| San Diego | 149 of 228 elements — every way and relation gone |
| Warendorf (DE) | 0 — the town has no surveyed nodes, so the screen is empty over a mapped Bundeswehr barracks |

Silent: no error, no warning, just missing installations.

## The fix

`out geom` ships `bounds` alongside exactly those elements — relations included, which carry no `geometry` at all — so `pointFrom` falls back to the midpoint of that box. No change to the query, no change to the footprint path.

## Tests

Four new cases in `src/data/militaryInstallationData.test.mjs`. Two fail on the unfixed normalizer (way and relation carrying only `bounds`); two are regression guards — an explicit `center` must keep winning, and a half-filled or out-of-range box must be dropped rather than averaged into a plausible-looking lie.

## Verification

`npm run build`, `npm test` (2591 passing) and `npm run test:track` (100/100) green.