### PR TITLE
feat(overpass): allow extra mirrors via OVERPASS_EXTRA_UPSTREAMS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -117,6 +117,13 @@ AISSTREAM_API_KEY=
 # Over the cap the proxy serves cached/stale tiles instead of hitting upstream.
 # TOMTOM_DAILY_TILE_BUDGET=40000
 
+# Optional: extra Overpass mirrors, tried BEFORE the built-in list. Set this if
+# the built-in mirrors are blocked or rate-limited from your network — every
+# Overpass-backed layer (traffic, mapped installations, OSM webcams) depends on
+# them. Whitespace- or comma-separated. Planet-wide instances only: a regional
+# extract answers HTTP 200 with an empty result, which gets cached for 24 h.
+# OVERPASS_EXTRA_UPSTREAMS=
+
 # Optional: CCTV layer tuning (advanced). Defaults are sensible — leave unset
 # unless you're customizing the camera source pack.
 # CCTV_SOURCES_FILE=config/cctv_sources.austin.json   # path to a source-pack JSON

--- a/src/data/overpassUpstreams.test.mjs
+++ b/src/data/overpassUpstreams.test.mjs
@@ -1,0 +1,38 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { parseExtraOverpassUpstreams } from '../../vite.config.js';
+
+// ---------------------------------------------------------------------------
+// parseExtraOverpassUpstreams — operator-supplied mirrors
+// ---------------------------------------------------------------------------
+
+test('extra upstreams accept whitespace- and comma-separated URLs, in order', () => {
+  assert.deepEqual(
+    parseExtraOverpassUpstreams('https://a.example/api/interpreter, https://b.example/api/interpreter'),
+    ['https://a.example/api/interpreter', 'https://b.example/api/interpreter'],
+  );
+  assert.deepEqual(
+    parseExtraOverpassUpstreams('https://a.example/i\n https://b.example/i'),
+    ['https://a.example/i', 'https://b.example/i'],
+  );
+  assert.deepEqual(parseExtraOverpassUpstreams(''), []);
+  assert.deepEqual(parseExtraOverpassUpstreams(undefined), []);
+});
+
+test('a private or localhost mirror is allowed — unlike a webcam URL, this comes from the operator', () => {
+  // The SSRF refusal in osmWebcamStillUrl guards a world-editable OSM tag. This
+  // value is the operator's own env, where a self-hosted instance is the point.
+  assert.deepEqual(parseExtraOverpassUpstreams('http://localhost:12345/api/interpreter'), ['http://localhost:12345/api/interpreter']);
+  assert.deepEqual(parseExtraOverpassUpstreams('http://10.0.0.9/api/interpreter'), ['http://10.0.0.9/api/interpreter']);
+});
+
+test('unusable extra upstreams are dropped, not passed through to the fetch loop', () => {
+  assert.deepEqual(parseExtraOverpassUpstreams('not-a-url ftp://x.example/i https://u:p@x.example/i'), []);
+});
+
+test('duplicate extra upstreams collapse so one mirror is not tried twice', () => {
+  assert.deepEqual(
+    parseExtraOverpassUpstreams('https://a.example/i https://a.example/i'),
+    ['https://a.example/i'],
+  );
+});

--- a/vite.config.js
+++ b/vite.config.js
@@ -152,6 +152,76 @@ const OVERPASS_UPSTREAMS = [
   'https://overpass.private.coffee/api/interpreter',
 ];
 /**
+ * Extra Overpass mirrors from OVERPASS_EXTRA_UPSTREAMS, tried BEFORE the
+ * built-in list.
+ *
+ * This exists because the built-in mirrors are not reachable from everywhere.
+ * Field note 2026-08-28: from one German consumer connection every one of them
+ * failed at once — overpass-api.de and lz4 refused TCP outright, and
+ * kumi.systems is a CNAME onto private.coffee, so the list held fewer distinct
+ * hosts than it looks like. Every Overpass-backed layer (traffic, mapped
+ * installations, the OSM webcam pack) was dead with no way to fix it short of
+ * editing this file. A network-local mirror belongs in the operator's
+ * environment, not in the repo's default list.
+ *
+ * Extras go FIRST: a mirror someone configured deliberately is a better first
+ * try than one that just timed out for them, and each dead built-in costs a
+ * full OVERPASS_TIMEOUT_MS before the chain moves on.
+ *
+ * **Only add planet-wide instances.** A REGIONAL extract is the dangerous case:
+ * overpass.osm.ch answers fast with HTTP 200 but serves Switzerland only, so
+ * every query outside CH returns an empty element list — which this proxy then
+ * caches as a valid result for 24 h. It fails silently, not loudly.
+ *
+ * @param {string} raw Whitespace/comma-separated URL list.
+ * @returns {Array<string>} Valid absolute http(s) endpoint URLs, in order.
+ */
+export function parseExtraOverpassUpstreams(raw) {
+  const out = [];
+  for (const token of String(raw ?? '').split(/[\s,]+/)) {
+    if (!token) continue;
+    let url;
+    try {
+      url = new URL(token);
+    } catch {
+      console.warn(`[Overpass] ignoring unparseable OVERPASS_EXTRA_UPSTREAMS entry: ${token}`);
+      continue;
+    }
+    // Structural checks only. Unlike osmWebcamStillUrl — whose input is a
+    // world-editable OSM tag — this value comes from the operator's own env, so
+    // a private or localhost address is a legitimate self-hosted instance
+    // rather than an SSRF target, and is deliberately allowed.
+    if ((url.protocol !== 'http:' && url.protocol !== 'https:') || url.username || url.password || !url.hostname) {
+      console.warn(`[Overpass] ignoring unusable OVERPASS_EXTRA_UPSTREAMS entry: ${token}`);
+      continue;
+    }
+    if (!out.includes(url.href)) out.push(url.href);
+  }
+  return out;
+}
+
+/** @type {{raw: string|null, list: Array<string>}} Memo for the resolved chain. */
+let _overpassUpstreamMemo = { raw: null, list: OVERPASS_UPSTREAMS };
+
+/**
+ * The mirror chain to try, extras first.
+ *
+ * Resolved lazily and re-resolved when the env value changes: module evaluation
+ * happens BEFORE Vite's loadEnv() copies .env into process.env, so reading the
+ * variable at module scope would always see undefined.
+ *
+ * @returns {Array<string>} Ordered endpoint URLs.
+ */
+function resolveOverpassUpstreams() {
+  const raw = process.env.OVERPASS_EXTRA_UPSTREAMS ?? '';
+  if (_overpassUpstreamMemo.raw !== raw) {
+    const extra = parseExtraOverpassUpstreams(raw);
+    if (extra.length) console.log(`[Overpass] ${extra.length} extra upstream(s) from OVERPASS_EXTRA_UPSTREAMS, tried first`);
+    _overpassUpstreamMemo = { raw, list: [...extra, ...OVERPASS_UPSTREAMS] };
+  }
+  return _overpassUpstreamMemo.list;
+}
+/**
  * TTL for FRESH cached Overpass responses (ms). Road geometry is static for
  * months — the original 45 s TTL forced a public-mirror round-trip on nearly
  * every viewport revisit and left nothing to serve when the mirrors 502
@@ -2512,7 +2582,7 @@ async function fetchOverpassPayload(body, maxResponseBytes = OVERPASS_MAX_RESPON
   let lastError = null;
   let lastRateLimitPayload = null;
 
-  for (const endpoint of OVERPASS_UPSTREAMS) {
+  for (const endpoint of resolveOverpassUpstreams()) {
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), OVERPASS_TIMEOUT_MS);
 


### PR DESCRIPTION
## Why

The built-in mirror list is not reachable from everywhere. From one German consumer connection every entry failed at once — `overpass-api.de` and `lz4` refused TCP outright, and `overpass.kumi.systems` is a CNAME onto `private.coffee`, so the list holds fewer distinct hosts than it looks like.

Traffic, mapped installations and every other Overpass-backed layer were dead, with no fix short of editing `vite.config.js`. A network-local mirror belongs in the operator's environment, not in the repo's default list.

## What

`OVERPASS_EXTRA_UPSTREAMS` (whitespace- or comma-separated) is tried **before** the built-ins: a mirror someone configured deliberately is a better first try than one that just timed out for them, and each dead built-in costs a full `OVERPASS_TIMEOUT_MS` before the chain moves on.

Resolved lazily and re-resolved when the value changes, because module evaluation runs before Vite's `loadEnv()` copies `.env` into `process.env` — the file already documents that trap elsewhere.

Validation is **structural only**. Unlike a world-editable OSM tag, this value comes from the operator's own env, so a private or localhost address is a legitimate self-hosted instance rather than an SSRF target, and is deliberately allowed. The JSDoc says so, so it does not get "hardened" later by mistake.

One warning carried over from the field: **only add planet-wide instances.** A regional extract such as `overpass.osm.ch` answers fast with HTTP 200 but serves Switzerland only, so every query outside CH returns an empty element list — which this proxy then caches as a valid result for 24 h. It fails silently, not loudly.

## Tests

`src/data/overpassUpstreams.test.mjs` — separator forms and order, private/localhost allowed, unusable entries dropped rather than passed to the fetch loop, duplicates collapsed.

## Verification

`npm run build`, `npm test` (2591 passing) and `npm run test:track` (100/100) green. Confirmed in the running dev server: `[Overpass] 1 extra upstream(s) from OVERPASS_EXTRA_UPSTREAMS, tried first`.