### PR TITLE
feat(installations): show OSM provenance in the popup and walk the viewport roster

### DIFF
--- a/index.html
+++ b/index.html
@@ -587,6 +587,26 @@
     </div>
   </div>
 
+  <!-- Mapped Installations walk: PREV/NEXT through the viewport roster. Hidden
+       unless the layer is on — it has nothing to say about an absent layer. -->
+  <div id="installations-nav" class="panel-collapsible collapsed" data-panel-id="installations-nav" hidden>
+    <div class="installations-nav-inner">
+      <div class="panel-header">
+        <span class="panel-title">INSTALLATIONS</span>
+        <span class="panel-divider"></span>
+        <button class="panel-collapse-btn" data-collapse-target="installations-nav" title="Collapse panel">+</button>
+      </div>
+      <div class="installations-nav-body">
+        <div class="installations-nav-row">
+          <button id="installations-prev-btn" type="button" aria-label="Previous mapped installation" title="Previous installation (,)">◀</button>
+          <output id="installations-nav-count" aria-live="polite">— / —</output>
+          <button id="installations-next-btn" type="button" aria-label="Next mapped installation" title="Next installation (.)">▶</button>
+        </div>
+        <span id="installations-nav-label" class="installations-nav-label">NOTHING SELECTED</span>
+      </div>
+    </div>
+  </div>
+
   <!-- CCTV Coverage Panel -->
   <div id="cctv-panel" class="panel-collapsible collapsed" data-panel-id="cctv-panel">
     <div class="panel-glow"></div>

--- a/src/data/militaryInstallationData.js
+++ b/src/data/militaryInstallationData.js
@@ -51,6 +51,27 @@ function finiteLongitude(value) {
   return Number.isFinite(value) && value >= -180 && value <= 180;
 }
 
+/**
+ * OSM tags worth showing, in display order. Everything else is dropped: these
+ * are descriptive keys with stable meanings, not operational claims.
+ * @type {ReadonlyArray<string>}
+ */
+const DESCRIPTIVE_TAGS = Object.freeze(['short_name', 'operator', 'start_date', 'wikipedia', 'wikidata']);
+
+/**
+ * Copy the descriptive OSM tags off an element, trimmed and string-typed.
+ * @param {Object<string, unknown>} tags Raw OSM tags.
+ * @returns {Object<string, string>} Present tags only; empty when none apply.
+ */
+function pickDescriptiveTags(tags) {
+  const picked = {};
+  for (const key of DESCRIPTIVE_TAGS) {
+    const value = String(tags?.[key] ?? '').trim();
+    if (value) picked[key] = value;
+  }
+  return picked;
+}
+
 function pointFrom(element) {
   const lat = Number(element?.lat ?? element?.center?.lat);
   const longitude = Number(element?.lon ?? element?.center?.lon);
@@ -124,6 +145,13 @@ export function normalizeMilitaryInstallations(payload, retrievedAt = new Date()
       osmType: type,
       class: klass,
       name: String(tags.name || tags['name:en'] || '').trim() || humanizeInstallationClass(klass),
+      // A curated slice of the OSM tags, not the whole bag: mappers put real
+      // description on these keys (the Warendorf barracks carry short_name
+      // SportSBw, start_date 1957 and a Wikipedia article), and dropping every
+      // tag left the popup unable to say anything a viewer could not already
+      // see. Copied by name so an arbitrary upstream tag can never reach the
+      // label, and trimmed to strings so the renderer needs no type checks.
+      osmTags: pickDescriptiveTags(tags),
       ...point,
       footprint: footprintFrom(element),
       sources: [{ name: 'OpenStreetMap', id: `${type}/${osmId}`, retrievedAt }],

--- a/src/data/militaryInstallationData.js
+++ b/src/data/militaryInstallationData.js
@@ -54,7 +54,27 @@ function finiteLongitude(value) {
 function pointFrom(element) {
   const lat = Number(element?.lat ?? element?.center?.lat);
   const longitude = Number(element?.lon ?? element?.center?.lon);
-  return finiteLatitude(lat) && finiteLongitude(longitude) ? { latitude: lat, longitude } : null;
+  if (finiteLatitude(lat) && finiteLongitude(longitude)) return { latitude: lat, longitude };
+
+  // Bounds midpoint fallback (field test 2026-08-28, Warendorf: nothing drawn).
+  // The proxy asks for `out center tags geom`, but Overpass takes the LAST
+  // geometry mode only — `geom` wins and no `center` is ever emitted. Every
+  // way and relation therefore arrived point-less and was dropped here, so the
+  // layer rendered nodes and nothing else (San Diego: 149 of 228 kept, all the
+  // ways and relations gone; Warendorf has no nodes at all, hence an empty
+  // screen over a mapped Bundeswehr barracks). `bounds` accompanies exactly
+  // those elements — including relations, which carry no `geometry` — so it
+  // recovers all of them without touching the query or the footprint path.
+  const bounds = element?.bounds;
+  const south = Number(bounds?.minlat);
+  const west = Number(bounds?.minlon);
+  const north = Number(bounds?.maxlat);
+  const east = Number(bounds?.maxlon);
+  if (finiteLatitude(south) && finiteLatitude(north)
+      && finiteLongitude(west) && finiteLongitude(east)) {
+    return { latitude: (south + north) / 2, longitude: (west + east) / 2 };
+  }
+  return null;
 }
 
 function footprintFrom(element) {

--- a/src/data/militaryInstallationData.test.mjs
+++ b/src/data/militaryInstallationData.test.mjs
@@ -125,3 +125,46 @@ test('an out-of-range or incomplete bounds box is dropped, not averaged', () => 
   assert.deepEqual(result.records, []);
   assert.equal(result.droppedCount, 5);
 });
+
+test('descriptive OSM tags are copied onto the record, by name and trimmed', () => {
+  const result = normalizeMilitaryInstallations({ elements: [
+    { type: 'way', id: 92701457, bounds: { minlat: 51.94, minlon: 7.98, maxlat: 51.96, maxlon: 8.02 },
+      tags: {
+        military: 'barracks',
+        name: 'Sportschule der Bundeswehr',
+        short_name: '  SportSBw  ',
+        operator: 'Bundeswehr',
+        start_date: '1957',
+        wikipedia: 'de:Sportschule der Bundeswehr',
+        wikidata: 'Q2311545',
+      } },
+  ] });
+  assert.deepEqual(result.records[0].osmTags, {
+    short_name: 'SportSBw',
+    operator: 'Bundeswehr',
+    start_date: '1957',
+    wikipedia: 'de:Sportschule der Bundeswehr',
+    wikidata: 'Q2311545',
+  });
+});
+
+test('only the named tags travel — an arbitrary upstream tag can never reach a label', () => {
+  const result = normalizeMilitaryInstallations({ elements: [
+    { type: 'node', id: 1, lat: 30, lon: -97, tags: {
+      military: 'range',
+      operator: 'US Army',
+      description: 'ignore me',
+      note: 'ignore me too',
+      'operator:type': 'government',
+      website: 'https://example.org',
+    } },
+  ] });
+  assert.deepEqual(result.records[0].osmTags, { operator: 'US Army' });
+});
+
+test('a feature with no descriptive tags carries an empty bag, never undefined', () => {
+  const result = normalizeMilitaryInstallations({ elements: [
+    { type: 'node', id: 2, lat: 30, lon: -97, tags: { military: 'range', short_name: '   ' } },
+  ] });
+  assert.deepEqual(result.records[0].osmTags, {});
+});

--- a/src/data/militaryInstallationData.test.mjs
+++ b/src/data/militaryInstallationData.test.mjs
@@ -74,3 +74,54 @@ test('accepts only small non-dateline request bboxes', () => {
   assert.equal(isValidInstallationBoundingBox({ south: -1, west: 179, north: 1, east: -179 }), false);
   assert.equal(isValidInstallationBoundingBox({ south: -20, west: 0, north: 20, east: 1 }), false);
 });
+
+test('a way with only bounds is kept, at the midpoint of that box', () => {
+  // The proxy asks for `out center tags geom` and Overpass honours only the
+  // LAST geometry mode, so `center` is never emitted and every way/relation
+  // arrives carrying `bounds` instead. Dropping those rendered nodes and
+  // nothing else — an empty screen over mapped installations.
+  const result = normalizeMilitaryInstallations({ elements: [
+    { type: 'way', id: 92701457, bounds: { minlat: 51.94, minlon: 7.98, maxlat: 51.96, maxlon: 8.02 },
+      tags: { military: 'barracks', name: 'Sportschule der Bundeswehr' } },
+  ] }, '2026-08-28T00:00:00.000Z');
+
+  assert.equal(result.records.length, 1);
+  assert.equal(result.droppedCount, 0);
+  assert.equal(result.records[0].latitude, 51.95);
+  assert.equal(result.records[0].longitude, 8.00);
+});
+
+test('a relation with only bounds is kept — it carries no geometry at all', () => {
+  const result = normalizeMilitaryInstallations({ elements: [
+    { type: 'relation', id: 5, bounds: { minlat: -1, minlon: -2, maxlat: 1, maxlon: 2 },
+      tags: { landuse: 'military' } },
+  ] });
+  assert.equal(result.records.length, 1);
+  assert.equal(result.records[0].latitude, 0);
+  assert.equal(result.records[0].longitude, 0);
+});
+
+test('an explicit centre still wins over bounds', () => {
+  const result = normalizeMilitaryInstallations({ elements: [
+    { type: 'way', id: 6, center: { lat: 30.2, lon: -97.7 },
+      bounds: { minlat: 0, minlon: 0, maxlat: 60, maxlon: 60 },
+      tags: { military: 'airfield' } },
+  ] });
+  assert.equal(result.records[0].latitude, 30.2);
+  assert.equal(result.records[0].longitude, -97.7);
+});
+
+test('an out-of-range or incomplete bounds box is dropped, not averaged', () => {
+  const result = normalizeMilitaryInstallations({ elements: [
+    // latitude past the pole
+    { type: 'way', id: 1, bounds: { minlat: 80, minlon: 0, maxlat: 95, maxlon: 1 }, tags: { military: 'range' } },
+    // longitude past the antimeridian
+    { type: 'way', id: 2, bounds: { minlat: 0, minlon: 170, maxlat: 1, maxlon: 181 }, tags: { military: 'range' } },
+    // a half-filled box would average to a plausible-looking lie
+    { type: 'way', id: 3, bounds: { minlat: 10, maxlat: 12 }, tags: { military: 'range' } },
+    { type: 'way', id: 4, bounds: {}, tags: { military: 'range' } },
+    { type: 'way', id: 5, tags: { military: 'range' } },
+  ] });
+  assert.deepEqual(result.records, []);
+  assert.equal(result.droppedCount, 5);
+});

--- a/src/data/militaryInstallations.js
+++ b/src/data/militaryInstallations.js
@@ -62,6 +62,19 @@ const state = {
   records: [],
   recordById: new Map(),
   selectedId: null,
+  /** Record under the cursor, or null. Presentation only — never persisted. */
+  hoveredId: null,
+  /** Exact keydown callback registered on document, so destroy() can remove it. */
+  keydownHandler: null,
+  /**
+   * Ordered installation ids for PREV/NEXT, or null when it needs rebuilding.
+   *
+   * Frozen on first use rather than recomputed per step, and deliberately not
+   * "always jump to the nearest": nearest-from-here ping-pongs between two
+   * mutual neighbours forever, and the counter would have no stable meaning.
+   * A fixed order makes "3 / 59" true and the walk exhaustive.
+   */
+  navOrder: null,
   lastUpdate: null,
   error: null,
   status: 'idle',
@@ -82,6 +95,110 @@ const state = {
 
 function colorFor(record) {
   return Cesium.Color.fromCssColorString(COLOR_BY_CLASS[record.class] || '#9ca6b0');
+}
+
+/**
+ * Popup detail lines for a mapped installation.
+ *
+ * The label used to carry the class alone, which made every unnamed feature
+ * read "MILITARY LAND" and nothing else — the provenance that decides whether
+ * a viewer should trust the marker (which mapper, which OSM object, how old,
+ * reviewed or not) was collected by registerEntityContext and then only ever
+ * read back by the voice agent. These lines put it on screen.
+ *
+ * Pure and export-only so the wording is testable without a Cesium viewer.
+ * @param {object} record Normalized installation record.
+ * @returns {Array<string>} Rendered detail lines, in display order.
+ */
+export function installationDetailLines(record) {
+  const lines = [String(record?.class || 'installation').replaceAll('_', ' ').toUpperCase()];
+
+  // `osm:way:92701457` → `OSM WAY/92701457`: the reference a viewer can paste
+  // into openstreetmap.org to see the mapper, the history and the full tags.
+  const osmMatch = /^osm:(node|way|relation):(\d+)$/.exec(String(record?.id || ''));
+  if (osmMatch) lines.push(`OSM ${osmMatch[1].toUpperCase()}/${osmMatch[2]}`);
+
+  // Descriptive OSM tags, when the mappers supplied them. `wikipedia` arrives
+  // as `de:Sportschule der Bundeswehr`; the language prefix is the lookup key,
+  // so it stays. `wikidata` is only offered when no article exists — the two
+  // together would spend three of five lines on the same fact.
+  const tags = record?.osmTags || {};
+  if (tags.short_name) lines.push(`AKA ${tags.short_name}`);
+  if (tags.operator) lines.push(`OPERATOR · ${tags.operator.toUpperCase()}`);
+  if (tags.start_date) lines.push(`SINCE ${tags.start_date}`);
+  if (tags.wikipedia) lines.push(`WIKIPEDIA ${tags.wikipedia}`);
+  else if (tags.wikidata) lines.push(`WIKIDATA ${tags.wikidata}`);
+
+  const source = installationSourceLabel(record);
+  if (source) lines.push(`SOURCE · ${source.toUpperCase()}`);
+
+  // Google Places candidates are name matches, not mapped military land. Their
+  // type is the only thing separating them from an OSM-tagged installation.
+  const placeType = String(record?.primaryType || '').trim();
+  if (placeType) lines.push(`PLACE TYPE · ${placeType.replaceAll('_', ' ').toUpperCase()}`);
+
+  // Every record ships `validation: 'unreviewed'`. Saying so is the point: this
+  // layer is community mapping, and the README calls it incomplete by nature.
+  const validation = String(record?.validation || '').trim();
+  if (validation) lines.push(validation.toUpperCase());
+
+  const retrieved = Date.parse(record?.retrievedAt);
+  if (Number.isFinite(retrieved)) {
+    lines.push(`RETRIEVED ${new Date(retrieved).toISOString().slice(0, 16).replace('T', ' ')}Z`);
+  }
+  return lines;
+}
+
+/**
+ * Which emphasis a record carries this paint. Selection outranks hover so a
+ * selected footprint does not dim when the cursor wanders onto a neighbour.
+ * @param {string} id Record id.
+ * @returns {'selected'|'hovered'|null}
+ */
+function emphasisFor(id) {
+  if (id === state.selectedId) return 'selected';
+  if (id === state.hoveredId) return 'hovered';
+  return null;
+}
+
+/** Point size/colour for an emphasis level. */
+function pointStyleFor(color, emphasis) {
+  if (emphasis === 'selected') return { pixelSize: 13, color: Cesium.Color.WHITE };
+  if (emphasis === 'hovered') return { pixelSize: 11, color: Cesium.Color.WHITE.withAlpha(0.85) };
+  return { pixelSize: 9, color };
+}
+
+/**
+ * Footprint fill/outline for an emphasis level.
+ *
+ * Selection previously changed the POINT only, so clicking a footprint left the
+ * area itself at its resting 12 % fill and the only lasting feedback was a dot
+ * two pixels wider — field report: "the area highlights once and then nothing".
+ * Cesium ignores polygon outlineWidth on most platforms, so the emphasis has to
+ * ride on alpha.
+ */
+function polygonStyleFor(color, emphasis) {
+  if (emphasis === 'selected') return { material: color.withAlpha(0.34), outlineColor: Cesium.Color.WHITE.withAlpha(0.95) };
+  if (emphasis === 'hovered') return { material: color.withAlpha(0.22), outlineColor: color.withAlpha(0.9) };
+  return { material: color.withAlpha(0.12), outlineColor: color.withAlpha(0.65) };
+}
+
+/**
+ * Repaint for the current selection/hover.
+ *
+ * Nothing is assigned here on purpose. The entities read their emphasis through
+ * CallbackProperties (see renderRecords), so a hover change only needs a frame.
+ *
+ * Writing `entity.polygon.material` directly — the first attempt — made hover
+ * flicker: assigning a material rebuilds the polygon's geometry, and during the
+ * rebuild frame the primitive is gone, so the next MOUSE_MOVE pick returns null,
+ * clears `hoveredId`, and schedules the opposite rebuild. The cursor sitting
+ * still on one footprint oscillated. Callbacks keep the geometry static and move
+ * only a per-instance colour attribute, which is also far cheaper.
+ * @returns {void}
+ */
+function applyEmphasis() {
+  governorRequestRender('installations-emphasis');
 }
 
 /**
@@ -252,21 +369,30 @@ function renderRecords() {
       record.latitude,
       surfaceHeightM,
     );
+    // Emphasis rides on CallbackProperties rather than on assignments made when
+    // the hover changes: a material assignment rebuilds the polygon geometry,
+    // and the resulting empty pick frame fed a flicker loop (see applyEmphasis).
+    // `false` marks each property non-constant so Cesium re-reads it per frame
+    // while keeping the geometry itself static.
+    const recordId = record.id;
+    const emphasis = () => emphasisFor(recordId);
     const entity = state.dataSource.entities.add({
       id: record.id,
       position: displayPosition,
       point: {
-        pixelSize: record.id === state.selectedId ? 13 : 9,
-        color: record.id === state.selectedId ? Cesium.Color.WHITE : color,
+        pixelSize: new Cesium.CallbackProperty(() => pointStyleFor(color, emphasis()).pixelSize, false),
+        color: new Cesium.CallbackProperty(() => pointStyleFor(color, emphasis()).color, false),
         outlineColor: Cesium.Color.BLACK.withAlpha(0.8),
         outlineWidth: 1,
         disableDepthTestDistance: Number.POSITIVE_INFINITY,
       },
       polygon: record.footprint ? {
         hierarchy: new Cesium.PolygonHierarchy(record.footprint.map(([longitude, latitude]) => Cesium.Cartesian3.fromDegrees(longitude, latitude))),
-        material: color.withAlpha(0.12),
+        material: new Cesium.ColorMaterialProperty(
+          new Cesium.CallbackProperty(() => polygonStyleFor(color, emphasis()).material, false),
+        ),
         outline: true,
-        outlineColor: color.withAlpha(0.65),
+        outlineColor: new Cesium.CallbackProperty(() => polygonStyleFor(color, emphasis()).outlineColor, false),
         height: surfaceHeightM,
       } : undefined,
     });
@@ -274,7 +400,7 @@ function renderRecords() {
     entity.gevDisplayPosition = () => displayPosition;
     entity.gevLabelModel = {
       title: record.name || 'MAPPED INSTALLATION',
-      details: [String(record.class || 'installation').replaceAll('_', ' ').toUpperCase()],
+      details: installationDetailLines(record),
       accent: COLOR_BY_CLASS[record.class] || '#9ca6b0',
     };
     registerEntityContext(entity, {
@@ -335,6 +461,44 @@ function warmInstallationFloors(records) {
   });
 }
 
+/**
+ * Drop the current selection and its popup.
+ *
+ * Without this the label was a one-way door: `selectRecord` was the only writer
+ * of `selectedId`, and it only ever ran on a hit, so a click on empty terrain
+ * left the card standing over an installation the viewer had moved on from.
+ * Mirrors the vessel layer's click-away / Escape pair.
+ * @returns {boolean} Whether a selection was actually cleared.
+ */
+/**
+ * The PREV/NEXT walk order, built once per roster.
+ *
+ * Sorted by distance from where the camera is looking when navigation first
+ * starts, so NEXT from a standing start goes to the nearest installation rather
+ * than to whatever Overpass happened to list first.
+ * @returns {Array<string>} Installation ids, nearest first.
+ */
+function ensureNavOrder() {
+  if (Array.isArray(state.navOrder)) return state.navOrder;
+  const candidates = state.records.filter((record) => record.kind === 'installation');
+  const camera = state.viewer?.camera;
+  const origin = camera ? Cesium.Cartographic.fromCartesian(camera.positionWC) : null;
+  if (origin) {
+    candidates.sort((a, b) => approximateSurfaceDistanceM(origin.latitude, origin.longitude, a.latitude, a.longitude)
+      - approximateSurfaceDistanceM(origin.latitude, origin.longitude, b.latitude, b.longitude));
+  }
+  state.navOrder = candidates.map((record) => record.id);
+  return state.navOrder;
+}
+
+function deselectRecord() {
+  if (!state.selectedId) return false;
+  state.selectedId = null;
+  clearSelectedEntityContextForLayer(LAYER_ID);
+  renderRecords();
+  return true;
+}
+
 function selectRecord(id) {
   const record = state.recordById.get(id);
   if (!record || !state.dataSource) return false;
@@ -351,8 +515,34 @@ function installInteraction(viewer) {
     if (!state.enabled) return;
     const picked = viewer.scene.pick(click.position);
     const id = typeof picked?.id?.id === 'string' ? picked.id.id : null;
+    // Empty terrain AND another layer's entity both end this selection: the
+    // card belongs to whatever the viewer last pointed at, not to the last
+    // installation they happened to hit.
     if (id && state.recordById.has(id)) selectRecord(id);
+    else deselectRecord();
   }, Cesium.ScreenSpaceEventType.LEFT_CLICK);
+
+  // Hover emphasis. The pick runs on every mouse move, so the handler exits on
+  // an unchanged id before touching a single entity — restyling costs nothing
+  // while the cursor travels across an already-hovered footprint.
+  state.clickHandler.setInputAction((movement) => {
+    if (!state.enabled) return;
+    const picked = viewer.scene.pick(movement.endPosition);
+    const id = typeof picked?.id?.id === 'string' ? picked.id.id : null;
+    const next = id && state.recordById.has(id) ? id : null;
+    if (next === state.hoveredId) return;
+    state.hoveredId = next;
+    applyEmphasis();
+  }, Cesium.ScreenSpaceEventType.MOUSE_MOVE);
+
+  // Escape closes the card without moving the camera — the vessel layer's
+  // keyboard escape hatch, for a selection made near the edge of the view where
+  // there is no comfortable empty spot to click.
+  state.keydownHandler = (event) => {
+    if (!state.enabled || event.key !== 'Escape') return;
+    deselectRecord();
+  };
+  document.addEventListener('keydown', state.keydownHandler);
 }
 
 /**
@@ -486,6 +676,9 @@ async function loadInstallations() {
     if (requestAbort.signal.aborted || state.abort !== requestAbort || !state.enabled) return;
     state.records = records;
     state.recordById = new Map(state.records.map((record) => [record.id, record]));
+    // A new viewport is a new roster: the walk order and its "3 / 59" have to
+    // be rebuilt, or NEXT would step through ids that are no longer rendered.
+    state.navOrder = null;
     state.lastUpdate = Date.now();
     state.stale = payload.status === 'stale';
     // Even the exact-viewport retry can saturate in a dense area. Say so rather
@@ -545,6 +738,8 @@ const militaryInstallationsLayer = {
     if (state.dataSource) state.dataSource.show = false;
     clearSelectedEntityContextForLayer(LAYER_ID);
     state.selectedId = null;
+    // A stale hover would re-emphasize a record the next enable() renders.
+    state.hoveredId = null;
   },
   update() { return loadInstallations(); },
   /** Request a one-shot Google Maps Places search around the current map view. */
@@ -557,6 +752,8 @@ const militaryInstallationsLayer = {
     state.moveEndRemove?.();
     state.clickHandler?.destroy();
     state.clickHandler = null;
+    if (state.keydownHandler) document.removeEventListener('keydown', state.keydownHandler);
+    state.keydownHandler = null;
     clearRendered();
     if (state.dataSource && viewer) viewer.dataSources.remove(state.dataSource, true);
     state.dataSource = null;
@@ -622,6 +819,42 @@ const militaryInstallationsLayer = {
       { duration: 1.4 },
     );
     return true;
+  },
+  /**
+   * Move the selection one step through the viewport roster and fly there.
+   *
+   * Until now the only way to reach a second installation was Global Context,
+   * which needs a tracked aircraft or vessel as its subject — installations are
+   * a cohort there, never the subject. So "show me these one after another"
+   * had no answer at all for ground features.
+   * @param {number} delta +1 for next, -1 for previous.
+   * @returns {boolean} Whether a record was selected.
+   */
+  stepSelection(delta) {
+    const order = ensureNavOrder();
+    if (!order.length) return false;
+    const step = Number(delta) < 0 ? -1 : 1;
+    const current = state.selectedId ? order.indexOf(state.selectedId) : -1;
+    // No selection yet: NEXT opens at the nearest, PREV at the farthest, so the
+    // first keypress in either direction lands somewhere meaningful.
+    const index = current === -1
+      ? (step > 0 ? 0 : order.length - 1)
+      : (current + step + order.length) % order.length;
+    return this.focusById(order[index]);
+  },
+  /**
+   * Roster position for the navigation panel.
+   * @returns {{total:number, index:number, label:string|null}} `index` is
+   *   1-based, or 0 when nothing is selected.
+   */
+  getNavigationState() {
+    const order = ensureNavOrder();
+    const index = state.selectedId ? order.indexOf(state.selectedId) : -1;
+    return {
+      total: order.length,
+      index: index === -1 ? 0 : index + 1,
+      label: index === -1 ? null : (state.recordById.get(order[index])?.name || null),
+    };
   },
   getStats() {
     return {

--- a/src/data/militaryInstallations.test.mjs
+++ b/src/data/militaryInstallations.test.mjs
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import {
   approximateSurfaceDistanceM,
   classifyGoogleMilitaryPlace,
+  installationDetailLines,
   installationSourceLabel,
   installationResponseSaturated,
   installationSurfaceHeightM,
@@ -742,4 +743,203 @@ test('the retry is wired to every lifecycle edge, not just declared', () => {
   assert.match(installationsSource,
     /state\.enabled && !state\.loading\) loadInstallations\(\)/,
     'the fired retry re-checks enablement and never races an in-flight load');
+});
+
+// ---------------------------------------------------------------------------
+// installationDetailLines — what the popup is allowed to claim
+// ---------------------------------------------------------------------------
+
+test('the popup names the OSM object a viewer can go and check', () => {
+  const lines = installationDetailLines({
+    id: 'osm:way:92701457',
+    class: 'barracks',
+    validation: 'unreviewed',
+    sources: [{ name: 'OpenStreetMap' }],
+    osmTags: { short_name: 'SportSBw', operator: 'Bundeswehr', start_date: '1957' },
+    retrievedAt: '2026-08-28T21:07:00.000Z',
+  });
+  assert.equal(lines[0], 'BARRACKS');
+  // Pasteable into openstreetmap.org — the mapper, the history, the full tags.
+  assert.ok(lines.includes('OSM WAY/92701457'));
+  assert.ok(lines.includes('AKA SportSBw'));
+  assert.ok(lines.includes('OPERATOR · BUNDESWEHR'));
+  assert.ok(lines.includes('SINCE 1957'));
+  assert.ok(lines.includes('UNREVIEWED'), 'community mapping must say so');
+  assert.ok(lines.includes('RETRIEVED 2026-08-28 21:07Z'));
+});
+
+test('an unnamed feature says more than just its class', () => {
+  // The whole point: before this, every unnamed feature read "MILITARY LAND".
+  const lines = installationDetailLines({
+    id: 'osm:node:5', class: 'military_land', validation: 'unreviewed',
+    sources: [{ name: 'OpenStreetMap' }], osmTags: {},
+  });
+  assert.equal(lines[0], 'MILITARY LAND');
+  assert.ok(lines.length > 1);
+  assert.ok(lines.includes('OSM NODE/5'));
+});
+
+test('wikipedia wins over wikidata — the two together waste a line on one fact', () => {
+  const both = installationDetailLines({
+    id: 'osm:node:1', class: 'range', osmTags: { wikipedia: 'de:Foo', wikidata: 'Q1' },
+  });
+  assert.ok(both.includes('WIKIPEDIA de:Foo'));
+  assert.ok(!both.some((l) => l.startsWith('WIKIDATA')));
+
+  const only = installationDetailLines({
+    id: 'osm:node:1', class: 'range', osmTags: { wikidata: 'Q1' },
+  });
+  assert.ok(only.includes('WIKIDATA Q1'));
+});
+
+test('a Places candidate is marked as one, not passed off as mapped military land', () => {
+  const lines = installationDetailLines({
+    id: 'places:abc', class: 'installation', primaryType: 'military_base',
+    sources: [{ name: 'Google Places' }],
+  });
+  assert.ok(lines.includes('PLACE TYPE · MILITARY BASE'));
+  assert.ok(!lines.some((l) => l.startsWith('OSM ')));
+});
+
+test('missing fields are omitted, never rendered as empty or undefined', () => {
+  // An absent source is stated, not skipped — silence would read as vouched-for.
+  assert.deepEqual(installationDetailLines({ class: 'range' }),
+    ['RANGE', 'SOURCE · UNKNOWN MAPPED SOURCE']);
+  for (const record of [{}, null, undefined, { osmTags: null }]) {
+    const lines = installationDetailLines(record);
+    assert.ok(lines.length > 0);
+    assert.ok(lines.every((l) => l && !/undefined|NaN|Invalid/.test(l)), JSON.stringify(lines));
+  }
+  // An unparseable timestamp must drop the line rather than print Invalid Date.
+  assert.ok(!installationDetailLines({ class: 'range', retrievedAt: 'nonsense' })
+    .some((l) => l.startsWith('RETRIEVED')));
+});
+
+// ---------------------------------------------------------------------------
+// stepSelection — walking the viewport roster
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal viewer + fetch stand-in for the walk tests. Mirrors the harness used
+ * by the entity tests above; `elements` decides what the roster holds.
+ */
+function withWalkHarness(elements, run) {
+  const originalDocument = globalThis.document;
+  const originalWindow = globalThis.window;
+  const originalFetch = globalThis.fetch;
+  globalThis.document = { addEventListener() {}, removeEventListener() {} };
+  globalThis.window = { dispatchEvent() {} };
+  globalThis.fetch = async (url) => {
+    if (String(url).includes('/api/terrain/heights')) {
+      return { ok: true, status: 200, json: async () => ({ results: [{ ellipsoid: 100 }] }) };
+    }
+    return { ok: true, status: 200, json: async () => ({
+      status: 'fresh', retrievedAt: '2026-08-28T00:00:00.000Z', elements,
+    }) };
+  };
+  const dataSources = [];
+  const viewer = {
+    camera: {
+      moveEnd: { addEventListener() { return () => {}; } },
+      // Anchored at the south-west corner so nearest-first order is knowable.
+      positionWC: Cesium.Cartesian3.fromDegrees(-98, 30, 1_000_000),
+      // focusById flies to the picked record; the walk only cares that a
+      // selection was made, so the flight is a no-op that reports completion.
+      flyToBoundingSphere(_sphere, options) { options?.complete?.(); },
+      computeViewRectangle() {
+        return {
+          south: Cesium.Math.toRadians(29), west: Cesium.Math.toRadians(-99),
+          north: Cesium.Math.toRadians(32), east: Cesium.Math.toRadians(-96),
+        };
+      },
+    },
+    scene: { canvas: { addEventListener() {}, removeEventListener() {} },
+      globe: { ellipsoid: Cesium.Ellipsoid.WGS84 }, pick() { return null; } },
+    dataSources: {
+      add(ds) { dataSources.push(ds); return ds; },
+      remove(ds) { const i = dataSources.indexOf(ds); if (i >= 0) dataSources.splice(i, 1); return i >= 0; },
+    },
+  };
+  return (async () => {
+    try {
+      militaryInstallationsLayer.init(viewer);
+      militaryInstallationsLayer.enable();
+      await militaryInstallationsLayer.update();
+      return await run(viewer);
+    } finally {
+      militaryInstallationsLayer.destroy(viewer);
+      globalThis.fetch = originalFetch;
+      if (originalDocument === undefined) delete globalThis.document; else globalThis.document = originalDocument;
+      if (originalWindow === undefined) delete globalThis.window; else globalThis.window = originalWindow;
+    }
+  })();
+}
+
+const WALK_ELEMENTS = [
+  { type: 'node', id: 1, lat: 30.1, lon: -97.9, tags: { military: 'base', name: 'Alpha' } },
+  { type: 'node', id: 2, lat: 30.5, lon: -97.5, tags: { military: 'base', name: 'Bravo' } },
+  { type: 'node', id: 3, lat: 31.0, lon: -96.5, tags: { military: 'base', name: 'Charlie' } },
+];
+
+test('the walk visits every installation exactly once before repeating', async () => {
+  await withWalkHarness(WALK_ELEMENTS, async () => {
+    const seen = [];
+    for (let i = 0; i < 3; i++) {
+      assert.equal(militaryInstallationsLayer.stepSelection(1), true);
+      seen.push(militaryInstallationsLayer.getNavigationState().label);
+    }
+    assert.equal(new Set(seen).size, 3, `walk repeated itself: ${seen}`);
+    // A fixed order is what makes "3 / 3" true; nearest-from-here would
+    // ping-pong between two mutual neighbours forever.
+    militaryInstallationsLayer.stepSelection(1);
+    assert.equal(militaryInstallationsLayer.getNavigationState().label, seen[0]);
+  });
+});
+
+test('the counter is 1-based and reads 0 while nothing is selected', async () => {
+  await withWalkHarness(WALK_ELEMENTS, async () => {
+    const before = militaryInstallationsLayer.getNavigationState();
+    assert.equal(before.total, 3);
+    assert.equal(before.index, 0);
+    assert.equal(before.label, null);
+
+    militaryInstallationsLayer.stepSelection(1);
+    const first = militaryInstallationsLayer.getNavigationState();
+    assert.equal(first.index, 1);
+    assert.ok(first.label);
+  });
+});
+
+test('the first step opens at the nearest going forward, the farthest going back', async () => {
+  await withWalkHarness(WALK_ELEMENTS, async () => {
+    militaryInstallationsLayer.stepSelection(1);
+    const forward = militaryInstallationsLayer.getNavigationState();
+    assert.equal(forward.index, 1);
+    assert.equal(forward.label, 'Alpha', 'nearest to the camera anchor');
+  });
+  await withWalkHarness(WALK_ELEMENTS, async () => {
+    militaryInstallationsLayer.stepSelection(-1);
+    const back = militaryInstallationsLayer.getNavigationState();
+    assert.equal(back.index, 3);
+    assert.equal(back.label, 'Charlie', 'farthest from the camera anchor');
+  });
+});
+
+test('PREV and NEXT wrap in both directions', async () => {
+  await withWalkHarness(WALK_ELEMENTS, async () => {
+    militaryInstallationsLayer.stepSelection(1);
+    assert.equal(militaryInstallationsLayer.getNavigationState().index, 1);
+    militaryInstallationsLayer.stepSelection(-1);
+    assert.equal(militaryInstallationsLayer.getNavigationState().index, 3, 'PREV from the first wraps to the last');
+    militaryInstallationsLayer.stepSelection(1);
+    assert.equal(militaryInstallationsLayer.getNavigationState().index, 1, 'NEXT from the last wraps to the first');
+  });
+});
+
+test('an empty roster is inert rather than throwing', async () => {
+  await withWalkHarness([], async () => {
+    assert.equal(militaryInstallationsLayer.stepSelection(1), false);
+    assert.equal(militaryInstallationsLayer.stepSelection(-1), false);
+    assert.deepEqual(militaryInstallationsLayer.getNavigationState(), { total: 0, index: 0, label: null });
+  });
 });

--- a/src/ui.js
+++ b/src/ui.js
@@ -205,6 +205,7 @@ const SHARE_PANEL_STATE_SPECS = Object.freeze([
   { id: 'control-panel', pinnable: true },
   { id: 'location-bar', pinnable: true },
   { id: 'data-panel' },
+  { id: 'installations-nav' },
   { id: 'cctv-panel' },
   { id: 'radio-panel' },
   { id: 'scene-panel' },
@@ -215,6 +216,7 @@ const SHARE_PANEL_STATE_SPECS = Object.freeze([
 /** Standard map-view panels cleared out of the way on a fresh Cockpit entry. */
 const COCKPIT_ENTRY_COLLAPSE_PANEL_IDS = Object.freeze([
   'data-panel',
+  'installations-nav',
   'cctv-panel',
   'scene-panel',
   'pp-toggles',
@@ -2258,6 +2260,11 @@ export class StyleManager {
     this._cleanViewBtn = document.getElementById('clean-view-toggle');
     this._cleanViewExitBtn = document.getElementById('clean-view-exit');
     this._dataPanel = document.getElementById('data-panel');
+    this._installationsNav = document.getElementById('installations-nav');
+    this._installationsPrevBtn = document.getElementById('installations-prev-btn');
+    this._installationsNextBtn = document.getElementById('installations-next-btn');
+    this._installationsNavCount = document.getElementById('installations-nav-count');
+    this._installationsNavLabel = document.getElementById('installations-nav-label');
     this._scenePanel = document.getElementById('scene-panel');
     this._cctvPanel = document.getElementById('cctv-panel');
     this._radioPanel = document.getElementById('radio-panel');
@@ -3357,6 +3364,12 @@ export class StyleManager {
         this._updateHudButtonState();
         this._syncShareState();
       }
+      // Installation walk, on the media-player step convention. Guarded on the
+      // layer being enabled so the keys stay free for other bindings whenever
+      // Mapped Installations is off. Matched raw, not lower-cased: these are
+      // punctuation, and both sit unshifted on QWERTY and QWERTZ alike.
+      if (e.key === '.') this._stepInstallation(1);
+      if (e.key === ',') this._stepInstallation(-1);
       if (e.key.toLowerCase() === 'o') this._toggleOrbit();
       if (e.key.toLowerCase() === 'v') this.toggleCleanView();
       if (e.key.toLowerCase() === 'f') {
@@ -3466,6 +3479,14 @@ export class StyleManager {
       });
     }
 
+    this._installationsPrevBtn?.addEventListener('click', () => this._stepInstallation(-1));
+    this._installationsNextBtn?.addEventListener('click', () => this._stepInstallation(1));
+    // The roster is viewport-driven and the selection can also change by a
+    // direct click on a marker, so poll rather than chase every writer. One
+    // read of two integers per second is cheaper than the wiring would be.
+    this._installationsNavTimer = setInterval(() => this._updateInstallationsNav(), 1000);
+    this._updateInstallationsNav();
+
     if (this._celestialBtn) {
       this._celestialBtn.addEventListener('click', () => {
         const ringIsVisible = !!this.celestialRing?.visible;
@@ -3476,6 +3497,52 @@ export class StyleManager {
         }
       });
     }
+  }
+
+  /**
+   * Step the Mapped Installations selection and repaint the walk strip.
+   *
+   * Silently ignored while the layer is off, so the key stays free rather than
+   * appearing broken.
+   * @param {number} delta +1 next, -1 previous.
+   * @returns {void}
+   */
+  _stepInstallation(delta) {
+    if (!this._dataManager?.isEnabled?.('military-installations')) return;
+    militaryInstallationsLayer.stepSelection?.(delta);
+    this._updateInstallationsNav();
+  }
+
+  /**
+   * Show, hide and repaint the installation walk strip.
+   *
+   * Called on every data-layer change and after each step. The roster is
+   * viewport-driven, so the counter has to survive a camera move that swapped
+   * the whole list underneath a standing selection.
+   * @returns {void}
+   */
+  _updateInstallationsNav() {
+    if (!this._installationsNav) return;
+    const enabled = Boolean(this._dataManager?.isEnabled?.('military-installations'));
+    this._installationsNav.hidden = !enabled;
+    if (!enabled) return;
+
+    const nav = militaryInstallationsLayer.getNavigationState?.() || { total: 0, index: 0, label: null };
+    const empty = nav.total === 0;
+    if (this._installationsNavCount) {
+      this._installationsNavCount.textContent = empty
+        ? '— / —'
+        : `${nav.index || '—'} / ${nav.total}`;
+    }
+    if (this._installationsNavLabel) {
+      // An empty roster and an unselected one are different states, and the
+      // remedy differs too: zoom in versus press NEXT.
+      this._installationsNavLabel.textContent = empty
+        ? 'NONE IN VIEW — ZOOM IN'
+        : (nav.label || 'NOTHING SELECTED').toUpperCase();
+    }
+    if (this._installationsPrevBtn) this._installationsPrevBtn.disabled = empty;
+    if (this._installationsNextBtn) this._installationsNextBtn.disabled = empty;
   }
 
   /**
@@ -6764,6 +6831,13 @@ export class StyleManager {
       stack.insertBefore(this._cctvPanel, globalContextPanel);
       this._syncPanelCollapseButton(this._cctvPanel);
     }
+    // The installation walk is a per-layer control like CCTV, so it belongs to
+    // the same rail — authored in the left stack only because that is where the
+    // markup for a plain block sits; the rail is composed at runtime.
+    if (this._installationsNav) {
+      stack.insertBefore(this._installationsNav, globalContextPanel);
+      this._syncPanelCollapseButton(this._installationsNav);
+    }
     if (this._sliderPanel) {
       this._sliderPanel.style.removeProperty('top');
       this._sliderPanel.style.removeProperty('right');
@@ -7397,7 +7471,7 @@ export class StyleManager {
    * @returns {void}
    */
   _syncPanelCollapseButton(panelEl) {
-    const isRightRail = ['pp-toggles', 'cctv-panel', 'global-context-panel'].includes(panelEl?.id);
+    const isRightRail = ['pp-toggles', 'cctv-panel', 'global-context-panel', 'installations-nav'].includes(panelEl?.id);
     const collapsed = panelEl.classList.contains('collapsed');
     panelEl.querySelectorAll('.panel-collapse-btn[data-collapse-target]').forEach((btn) => {
       const owner = btn.closest('[data-panel-id], #param-slider-panel');
@@ -10231,6 +10305,10 @@ export class StyleManager {
     if (this._loadingFeedbackTicker) {
       clearInterval(this._loadingFeedbackTicker);
       this._loadingFeedbackTicker = null;
+    }
+    if (this._installationsNavTimer) {
+      clearInterval(this._installationsNavTimer);
+      this._installationsNavTimer = null;
     }
     if (this._leftStackLayoutFrame !== null) {
       cancelAnimationFrame(this._leftStackLayoutFrame);

--- a/style.css
+++ b/style.css
@@ -9161,3 +9161,119 @@ body.scene-playback-mode #first-run-launcher {
   /* Scrolling a tile into view must not animate either. */
   .first-run-choices { scroll-behavior: auto; }
 }
+
+/* ── Mapped Installations walk ─────────────────────────────────────────────
+   Composed into #right-context-rail at runtime beside CCTV and CONTEXT (see
+   _initRightPanelAdaptiveLayout) — the markup lives in the left stack only
+   because that is where a plain block is authored. Rail panels collapse to a
+   narrow tab with a ◀/▶ toggle rather than the left stack's +/−. */
+#right-context-rail > #installations-nav {
+  position: relative;
+  top: auto;
+  right: auto;
+  bottom: auto;
+  left: auto;
+  z-index: auto;
+  width: 100%;
+  flex: 0 0 auto;
+  min-height: 0;
+  /* The rail is click-through; each panel re-arms its own hit area. Omitting
+     this let clicks fall past PREV/NEXT onto the globe while the keyboard
+     bindings still worked. */
+  pointer-events: auto;
+}
+
+#right-context-rail > #installations-nav.collapsed {
+  width: var(--right-context-collapsed-width);
+  margin-left: auto;
+}
+
+.installations-nav-inner {
+  padding: 14px 16px 12px;
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--panel-radius);
+  backdrop-filter: blur(24px) saturate(1.4);
+  -webkit-backdrop-filter: blur(24px) saturate(1.4);
+  box-shadow:
+    0 8px 32px rgba(0, 0, 0, .5),
+    0 0 0 1px rgba(255, 255, 255, .03) inset;
+}
+
+#installations-nav.collapsed .installations-nav-body {
+  display: none;
+}
+
+/* Matches the collapsed tab height its rail siblings agree on. */
+#installations-nav.collapsed .installations-nav-inner {
+  height: 50px;
+  min-height: 50px;
+  box-sizing: border-box;
+  padding-bottom: 10px;
+}
+
+#installations-nav.collapsed .panel-header {
+  margin-bottom: 2px;
+}
+
+#installations-nav.collapsed .panel-title {
+  font-size: 8px;
+  letter-spacing: 1.8px;
+}
+
+.installations-nav-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.installations-nav-row button {
+  min-width: 34px;
+  min-height: 26px;
+  border: 1px solid rgba(65, 220, 231, .28);
+  border-radius: 5px;
+  color: #8feaf2;
+  background: rgba(14, 69, 78, .14);
+  font: 10px/1 var(--font-mono);
+  cursor: pointer;
+  transition: border-color var(--transition-fast), color var(--transition-fast);
+}
+
+.installations-nav-row button:hover:not(:disabled),
+.installations-nav-row button:focus-visible:not(:disabled) {
+  border-color: #65f7ff;
+  color: #fff;
+}
+
+.installations-nav-row button:disabled {
+  opacity: .35;
+  cursor: default;
+}
+
+#installations-nav-count {
+  flex: 1;
+  text-align: center;
+  color: #cfeff3;
+  font: 11px/1 var(--font-mono);
+  letter-spacing: .08em;
+}
+
+.installations-nav-label {
+  display: block;
+  margin-top: 8px;
+  color: rgba(207, 239, 243, .62);
+  font: 9px/1.3 var(--font-mono);
+  letter-spacing: .06em;
+  /* One line, ellipsised: "Sportschule der Bundeswehr" must not reflow the
+     rail and shove CONTEXT down on every step. */
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+body.ui-clean-view #installations-nav,
+body.recording-mode #installations-nav {
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+}


### PR DESCRIPTION
> **Stacked on #102.** The first two commits of this branch *are* #102 (the bounds fix and its tests) — a fork PR cannot target a branch that does not exist upstream, so this is opened against `main` and its diff currently shows both. Merge #102 first and this shrinks to the three follow-up commits. Reviewing #102 on its own is the better read; it is an unrelated silent-data-loss bug that should not wait on this feature.

## 1 — Provenance in the popup

The label carried the class alone, so every unnamed feature read `MILITARY LAND` and nothing else. The provenance that decides whether a viewer should trust a marker — which OSM object, which operator, how old, reviewed or not — was already collected by `registerEntityContext` and then only ever read back by the voice agent.

`normalizeMilitaryInstallations` now copies a fixed, **named** slice of tags (`short_name`, `operator`, `start_date`, `wikipedia`, `wikidata`) onto the record, trimmed to strings, so an arbitrary upstream tag can never reach a label. `installationDetailLines` renders them and is pure, so the wording is testable without a Cesium viewer.

Small deliberate choices: the OSM id is rendered pasteable (`OSM WAY/92701457`); `wikipedia` wins over `wikidata` so the two do not spend two lines on one fact; a Places candidate is marked as one rather than passed off as mapped military land; an absent source is stated as unknown rather than omitted, because silence would read as vouched-for.

## 2 — Hover emphasis and a PREV/NEXT walk

Until now the only way to reach a second installation was Global Context, which needs a tracked aircraft or vessel as its subject — installations are a cohort there, never the subject. So "show me these one after another" had no answer at all for ground features.

Points and footprints now emphasise on hover, and a collapsible strip in the right rail walks the viewport roster, bound to `,` and `.` (the media-player step convention; matched raw, since both sit unshifted on QWERTY and QWERTZ). The keys are guarded on the layer being enabled, so they stay free otherwise.

**The walk order is frozen on first use rather than recomputed per step.** Nearest-from-here ping-pongs between two mutual neighbours forever, and the counter would have no stable meaning; a fixed order makes "3 / 59" true and the walk exhaustive.

## Tests

- `osmTags`: the named slice is copied and trimmed, an arbitrary tag (`description`, `note`, `website`) never travels, a feature with nothing descriptive gets an empty bag rather than `undefined`.
- `installationDetailLines`: an unnamed feature says more than its class, wikipedia beats wikidata, a Places candidate is marked, an unparseable timestamp drops its line instead of printing `Invalid Date`.
- `stepSelection`: every record is visited once before repeating, the counter is 1-based and zero while nothing is selected, the first step opens at the nearest going forward and the farthest going back, both directions wrap, an empty roster is inert rather than throwing.

## Verification

`npm run build`, `npm test` (2604 passing) and `npm run test:track` (100/100) green.

## Note for review

The nav strip polls the roster once per second (`setInterval`) rather than chasing every writer — the roster is viewport-driven and the selection can also change by a direct marker click. It reads two integers and requests no render, so it does not touch the render governor, but if you would rather have it event-driven, say so and I will wire it.