### PR TITLE
fix: Windows CRLF test portability in reasonableDefaults.test.mjs (#88)

### DIFF
--- a/src/reasonableDefaults.test.mjs
+++ b/src/reasonableDefaults.test.mjs
@@ -38,9 +38,14 @@ import {
 } from './scopeMask.js';
 import { ShareLinkManager } from './sharelink.js';
 
-const uiSource = fs.readFileSync(new URL('./ui.js', import.meta.url), 'utf8');
-const indexHtml = fs.readFileSync(new URL('../index.html', import.meta.url), 'utf8');
-const shareSource = fs.readFileSync(new URL('./sharelink.js', import.meta.url), 'utf8');
+// Anchors below are LF literals (e.g. '\n  }\n'). Normalize CRLF checkouts
+// (Windows, core.autocrlf=true — #88) so substring search isn't line-ending
+// sensitive; a straight indexOf already tolerates CRLF for anchors that don't
+// straddle a line ending, which is why only some anchors used to fail.
+const normalizeEol = (text) => text.replace(/\r\n/g, '\n');
+const uiSource = normalizeEol(fs.readFileSync(new URL('./ui.js', import.meta.url), 'utf8'));
+const indexHtml = normalizeEol(fs.readFileSync(new URL('../index.html', import.meta.url), 'utf8'));
+const shareSource = normalizeEol(fs.readFileSync(new URL('./sharelink.js', import.meta.url), 'utf8'));
 
 /** Slice ui.js between two literal anchors, so a pin reads one method, not the file. */
 function uiBlock(start, end) {


### PR DESCRIPTION
Closes #88.

`node --test src/reasonableDefaults.test.mjs` reads `src/ui.js` with a hardcoded LF-only source anchor. On a Windows checkout with `core.autocrlf=true`, `ui.js` uses CRLF line endings, so the anchor is never found — 8/9 tests pass instead of 9/9.

## Fix

Normalize CRLF to LF before the anchor search, so the result doesn't depend on git's line-ending config.

## Verification

Ran on an actual Windows/CRLF checkout: 9/9 pass (was 8/9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)