### PR TITLE
fix: make GOOGLE_MAPS_API_KEY optional, fall back Google 3D Tiles -> Cesium ion -> OSM globe (#59, #64, #71)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,7 +16,11 @@
 # WILL be visible in devtools. Restrict/scope them rather than trying to hide
 # them (see SECURITY.md). All other keys below stay server-side.
 
-# Required: Google Maps API key (Map Tiles API must be enabled).
+# Optional: Google Maps API key (Map Tiles API must be enabled), used for
+# Google Photorealistic 3D Tiles and the geocoder/places endpoints below.
+# Without it (or if your account can't reach the Map Tiles API — EEA billing
+# accounts get a 401), 3D tiles fall back to CESIUM_ION_TOKEN below, then to
+# the free keyless OSM globe.
 # CLIENT-EXPOSED — restrict it (HTTP referrer + API restriction) in Google Cloud.
 GOOGLE_MAPS_API_KEY=your_google_maps_api_key_here
 # Optional: opt-in per-IP rate limit for the Google Places cost endpoint
@@ -30,7 +34,10 @@ GOOGLE_MAPS_API_KEY=your_google_maps_api_key_here
 # (plus per-API quotas under APIs & Services -> Quotas).
 # GEV_RATELIMIT_GOOGLE_PER_MIN=60
 
-# Optional: Cesium ion token for Bing world imagery stacks and Cesium World Terrain.
+# Optional: Cesium ion token for Bing world imagery stacks, Cesium World
+# Terrain, and (without GOOGLE_MAPS_API_KEY, or where it 401s) Google
+# Photorealistic 3D Tiles via Cesium ion's mirror of the same imagery. Free
+# "Community" account is enough — just an "assets:read" token.
 # CLIENT-EXPOSED — use a public assets:read token with URL restrictions.
 CESIUM_ION_TOKEN=
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The live layers are grounded in public feeds: the airliner crossing your screen 
 
 Requires Node.js 24.14.x or 26.x (enforced by `package.json`).
 
-1. Copy `.env.example` → `.env` and set `GOOGLE_MAPS_API_KEY`.
+1. Copy `.env.example` → `.env` and set `GOOGLE_MAPS_API_KEY` (optional — skip it for the free OSM globe, or set `CESIUM_ION_TOKEN` instead for photorealistic 3D via Cesium ion, see [#71](https://github.com/bilawalsidhu/gods-eye-view/issues/71)).
 2. Install and run:
 
 ```bash
@@ -84,15 +84,16 @@ npm run dev -- --host localhost --port 4173
 >
 > ```text
 > Clone https://github.com/bilawalsidhu/gods-eye-view and set it up on my machine.
-> Install everything it needs, walk me through getting the required Google Maps API
-> key step by step (plus any optional free keys I want), put the keys in .env, and
-> help me set a billing alert and a usage quota on the Google key so I can't
-> overspend. Then start the dev server and open it in my browser. I'm not a
-> developer — explain what you're doing as you go, and ask me before any step
-> that could cost money.
+> Install everything it needs, walk me through getting a Google Maps API key
+> step by step if I want the photorealistic 3D globe (it's optional — the app
+> runs on the free OSM globe with no key at all), plus any other optional free
+> keys I want, put the keys in .env, and help me set a billing alert and a
+> usage quota on the Google key so I can't overspend. Then start the dev
+> server and open it in my browser. I'm not a developer — explain what you're
+> doing as you go, and ask me before any step that could cost money.
 > ```
 
-**That one key is the whole entry fee.** Everything in this README is color-coded — 🟢 needs nothing · 🟡 free key · 🔴 metered — and Google Maps is the only 🔴 you need: it buys the photorealistic planet, and most of the globe lights up 🟢 from there. For typical solo exploring, expect **$0 on most layers** and pocket change on the metered two: Google currently gives **1,000 free 3D-tile sessions a month** — each good for up to three hours of rendering, which is very hard for one person to exhaust — and voice carries a built-in $5 session cap. Full map in [Keys & Costs](#-api-keys), full honest breakdown in [What it actually costs](#-what-it-actually-costs).
+**No key is required to start.** Everything in this README is color-coded — 🟢 needs nothing · 🟡 free key · 🔴 metered — and Google Maps is the only 🔴 in the whole app: it buys the photorealistic planet (or use a free 🟡 `CESIUM_ION_TOKEN` for the same imagery via Cesium ion), while the free 🟢 OSM globe works with no key at all and most of the rest of the app lights up 🟢 from there. For typical solo exploring with the Google key set, expect **$0 on most layers** and pocket change on the one metered layer: Google currently gives **1,000 free 3D-tile sessions a month** — each good for up to three hours of rendering, which is very hard for one person to exhaust — and voice carries a built-in $5 session cap. Full map in [Keys & Costs](#-api-keys), full honest breakdown in [What it actually costs](#-what-it-actually-costs).
 
 The dev server binds to **localhost** — your keys stay on your machine. Sharing on a LAN safely is covered in [Sharing an instance](#-sharing-an-instance) and [SECURITY.md](SECURITY.md).
 

--- a/src/main.js
+++ b/src/main.js
@@ -79,15 +79,17 @@ async function init() {
       Cesium.Ion.defaultAccessToken = cesiumToken;
     }
 
-    // Set Google Maps API key for 3D Tiles
+    // Google Maps API key is optional (#59, #64): without one, or if Google's
+    // Map Tiles API rejects the key/billing account (EEA accounts get a 401 —
+    // #59), 3D tile loading below falls through to Cesium ion's mirror of the
+    // same imagery (#71), then to the keyless OSM/terrain stack (#64) instead
+    // of refusing to start.
     const googleApiKey = import.meta.env.GOOGLE_MAPS_API_KEY;
-    if (!googleApiKey) {
-      throw new Error('GOOGLE_MAPS_API_KEY not found. Set it as an environment variable.');
+    if (googleApiKey) {
+      Cesium.GoogleMaps.defaultApiKey = googleApiKey;
+      // Expose API key globally for geocoding in locations.js
+      window.__GOOGLE_MAPS_API_KEY__ = googleApiKey;
     }
-    Cesium.GoogleMaps.defaultApiKey = googleApiKey;
-
-    // Expose API key globally for geocoding in locations.js
-    window.__GOOGLE_MAPS_API_KEY__ = googleApiKey;
 
     // Create the Cesium viewer with minimal chrome
     const viewer = new Cesium.Viewer('cesiumContainer', {
@@ -153,22 +155,43 @@ async function init() {
     viewer.scene.skyAtmosphere.saturationShift = -0.12;
     viewer.scene.skyAtmosphere.brightnessShift = -0.08;
 
-    loaderStatus.textContent = 'Loading Google 3D Tiles...';
+    loaderStatus.textContent = 'Loading 3D Tiles...';
     let tileset = null;
-    try {
-      // Load Google Photorealistic 3D Tiles
-      tileset = await Cesium.createGooglePhotorealistic3DTileset({
-        onlyUsingWithGoogleGeocoder: true,
-      });
+    let tileErrorDetail = '';
+    if (googleApiKey) {
+      try {
+        // Preferred: Google Photorealistic 3D Tiles via the Google Maps Platform key.
+        tileset = await Cesium.createGooglePhotorealistic3DTileset({
+          onlyUsingWithGoogleGeocoder: true,
+        });
+      } catch (tileError) {
+        console.warn('[Init] Google 3D Tiles unavailable via Maps API key:', tileError);
+        tileErrorDetail = describeError(tileError);
+      }
+    }
+    if (!tileset && cesiumToken) {
+      try {
+        // Fallback (#71): Cesium ion mirrors Google Photorealistic 3D Tiles as
+        // a public global asset (id 2275207), reachable from accounts/regions
+        // where the Map Tiles API itself 401s (EEA billing, #59), using only
+        // a free Cesium ion "assets:read" token.
+        tileset = await Cesium.Cesium3DTileset.fromIonAssetId(2275207);
+      } catch (tileError) {
+        console.warn('[Init] Google 3D Tiles unavailable via Cesium ion:', tileError);
+        tileErrorDetail = tileErrorDetail || describeError(tileError);
+      }
+    }
+    if (tileset) {
       viewer.scene.primitives.add(tileset);
       // NOTE: Cesium World Terrain intentionally disabled — conflicts with Google 3D Tiles at high zoom.
       // Google Photorealistic 3D Tiles provide their own terrain/elevation.
       viewer.scene.globe.show = false;
-    } catch (tileError) {
-      console.warn('[Init] Google 3D Tiles unavailable, falling back to Cesium globe:', tileError);
-      const tileErrorDetail = describeError(tileError);
-      loaderStatus.textContent = `Google 3D Tiles unavailable (${tileErrorDetail}). Continuing in fallback mode...`;
-      // Keep Cesium globe visible as fallback instead of aborting the app.
+    } else {
+      // Keyless fallback (#64): no Google key, no Cesium token, or both failed —
+      // continue on the free OSM/terrain globe instead of aborting the app.
+      loaderStatus.textContent = tileErrorDetail
+        ? `3D Tiles unavailable (${tileErrorDetail}). Continuing in fallback mode...`
+        : 'Continuing with free OSM globe...';
       viewer.scene.globe.show = true;
     }
 


### PR DESCRIPTION
Closes #59, closes #64. Implements the fallback proposed in #71.

## Problem

`main.js` hard-throws at startup if `GOOGLE_MAPS_API_KEY` is unset — the app refuses to start at all without it (#64), and EEA billing accounts that get a 401 from the Map Tiles API directly (#59) have no recourse.

## Fix

New fallback chain instead of a hard throw:
1. Google Photorealistic 3D Tiles (unchanged — preferred when a Google Maps key is set and the account can reach the Map Tiles API)
2. Cesium ion's mirror of the same imagery (asset `2275207`, via `CESIUM_ION_TOKEN`) — the workaround from #71, which also fixes #59 since EEA accounts can reach the same tiles through Cesium ion even when the Map Tiles API itself 401s
3. The free, keyless OSM globe — already supported by `MapStackController`, just previously unreachable because the app refused to start at all without a Google key

`.env.example` and `README.md` updated to document both keys as optional and explain the fallback order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)