### PR TITLE
fix: add tooltips for visual-style presets and disabled/unavailable data layers (#90)

### DIFF
--- a/index.html
+++ b/index.html
@@ -492,37 +492,37 @@
       <div id="control-panel-popover" class="dock-popover-content">
       <button class="dock-pin-btn" data-pin-target="control-panel" type="button" aria-label="Pin visual presets" aria-pressed="false" title="Keep visual presets open"><img src="/pin.svg" alt="" /></button>
       <div id="style-buttons" class="button-grid">
-        <button class="style-btn active" data-style="normal">
+        <button class="style-btn active" data-style="normal" title="Normal — unfiltered photorealistic view">
           <span class="btn-icon">◯</span>
           <span class="btn-label">Normal</span>
           <span class="btn-key">1</span>
         </button>
-        <button class="style-btn" data-style="retro">
+        <button class="style-btn" data-style="retro" title="CRT — retro amber scanline monitor look">
           <span class="btn-icon">▦</span>
           <span class="btn-label">CRT</span>
           <span class="btn-key">2</span>
         </button>
-        <button class="style-btn" data-style="surveillance">
+        <button class="style-btn" data-style="surveillance" title="NVG — Night Vision Goggles: green monochrome night-vision look">
           <span class="btn-icon">🌙</span>
           <span class="btn-label">NVG</span>
           <span class="btn-key">3</span>
         </button>
-        <button class="style-btn" data-style="thermal">
+        <button class="style-btn" data-style="thermal" title="FLIR — Forward-Looking Infrared: thermal/heat-signature look">
           <span class="btn-icon">🌡️</span>
           <span class="btn-label">FLIR</span>
           <span class="btn-key">4</span>
         </button>
-        <button class="style-btn" data-style="anime">
+        <button class="style-btn" data-style="anime" title="Anime — stylized cel-shaded look">
           <span class="btn-icon">✦</span>
           <span class="btn-label">Anime</span>
           <span class="btn-key">5</span>
         </button>
-        <button class="style-btn" data-style="noir">
+        <button class="style-btn" data-style="noir" title="Noir — high-contrast black and white look">
           <span class="btn-icon">◐</span>
           <span class="btn-label">Noir</span>
           <span class="btn-key">6</span>
         </button>
-        <button class="style-btn" data-style="snow">
+        <button class="style-btn" data-style="snow" title="Snow — snow-covered winter terrain look">
           <span class="btn-icon">❄</span>
           <span class="btn-label">Snow</span>
           <span class="btn-key">7</span>

--- a/src/data/manager.js
+++ b/src/data/manager.js
@@ -2064,6 +2064,10 @@ export class DataLayerManager {
       const bottomRow = document.createElement('div');
       bottomRow.className = 'data-toggle-meta';
       bottomRow.textContent = this._buildMetaText(layer);
+      // Also as a hover tooltip (#90) — the meta line already carries the
+      // reason a layer is unavailable (e.g. "KEY REQUIRED"), but it's easy
+      // to miss as a permanently-visible line under a dense toggle grid.
+      row.title = bottomRow.textContent;
 
       row.appendChild(topRow);
       row.appendChild(bottomRow);
@@ -2201,6 +2205,7 @@ export class DataLayerManager {
       const meta = row.querySelector('.data-toggle-meta');
       if (meta) {
         meta.textContent = this._buildMetaText(layer);
+        row.title = meta.textContent;
       }
 
       this._syncRowControls(row.querySelector('.data-toggle-controls'), layer);


### PR DESCRIPTION
Closes #90 (the tooltip requests — the Docker/onboarding half of that issue is the maintainer's own separate in-progress work, per their comment on the issue).

## Changes

- `index.html`: native `title` attributes on the 7 VISUAL PRESETS buttons spelling out what CRT/NVG/FLIR/Noir/Anime/Snow mean, not just the abbreviation on the button.
- `src/data/manager.js`: each data-layer toggle row now carries the same status text already shown on its meta line (source, feed state, and any error like "KEY REQUIRED") as a hover title too, so the reason a layer is greyed out doesn't require spotting a small line of text under a dense toggle grid.

Both native `<title>` tooltips — no new UI/JS framework code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)