### PR TITLE
fix: remove node:fs from browser-built data modules (#34)

### DIFF
--- a/src/data/naturalEarthRegions.js
+++ b/src/data/naturalEarthRegions.js
@@ -113,19 +113,15 @@ function suffixVariants(norm) {
 /** @type {Array|null} flat entry list for listRegions() */
 let _entries = null;
 
-const isNode = typeof process !== 'undefined' && !!process.versions?.node
-  && typeof window === 'undefined';
-
+// A dynamic JSON import with an explicit `type: 'json'` attribute works
+// identically under Node's native loader (`node --test`, scripts/) and under
+// Vite (dev + build, still code-split into its own lazy chunk) — one path
+// for both, and neither one ever references `node:fs`, so the browser build
+// has nothing to externalize (#34).
 async function loadPackFile(base) {
-  if (isNode) {
-    const { readFileSync } = await import(/* @vite-ignore */ 'node:fs');
-    const url = new URL(`./local_data/natural_earth/${base}.json`, import.meta.url);
-    return JSON.parse(readFileSync(url, 'utf8'));
-  }
-  // Vite bundles these JSON files as modules (same pattern as neighborhoodPolygons.js)
   const mod = base === 'regions'
-    ? await import('./local_data/natural_earth/regions.json')
-    : await import('./local_data/natural_earth/marine.json');
+    ? await import('./local_data/natural_earth/regions.json', { with: { type: 'json' } })
+    : await import('./local_data/natural_earth/marine.json', { with: { type: 'json' } });
   return mod.default || mod;
 }
 

--- a/src/data/neighborhoodPolygons.js
+++ b/src/data/neighborhoodPolygons.js
@@ -13,12 +13,13 @@
 import { createRetryableLoader } from './retryableLoad.js';
 
 // bbox = [west, south, east, north]; only load a city file when the point falls in its box.
+// The `with { type: 'json' }` attribute works identically under Node's native
+// loader (`node --test`) and Vite (dev + build, still its own lazy chunk) —
+// one loader for both, no `node:fs` reference for the browser build to warn
+// about externalizing (#34).
 const CITY_FILES = [
-  { id: 'san-francisco', bbox: [-122.55, 37.70, -122.35, 37.84], loader: () => import('./local_data/neighborhoods/san-francisco.json') },
+  { id: 'san-francisco', bbox: [-122.55, 37.70, -122.35, 37.84], loader: () => import('./local_data/neighborhoods/san-francisco.json', { with: { type: 'json' } }) },
 ];
-
-const isNode = typeof process !== 'undefined' && !!process.versions?.node
-  && typeof window === 'undefined';
 
 /**
  * city id → memoized loader. Failures are NOT memoized: a transient
@@ -94,18 +95,8 @@ function cityLoader(city) {
   let loader = _cityLoaders.get(city.id);
   if (!loader) {
     loader = createRetryableLoader(async () => {
-      let fc;
-      if (isNode) {
-        // node:test path — plain dynamic JSON import needs an import attribute in Node,
-        // so read the file directly (same dual-path pattern as naturalEarthRegions.js).
-        const { readFileSync } = await import(/* @vite-ignore */ 'node:fs');
-        const url = new URL(`./local_data/neighborhoods/${city.id}.json`, import.meta.url);
-        fc = JSON.parse(readFileSync(url, 'utf8'));
-      } else {
-        // Vite bundles the JSON file as a module.
-        const mod = await city.loader();
-        fc = mod.default || mod;
-      }
+      const mod = await city.loader();
+      const fc = mod.default || mod;
       return Array.isArray(fc.features) ? fc.features : [];
     });
     _cityLoaders.set(city.id, loader);


### PR DESCRIPTION
Closes #34.

`npm run build` warns on every production build:

```
[plugin vite:resolve] Module "node:fs" has been externalized for browser compatibility, imported by "src/data/naturalEarthRegions.js".
[plugin vite:resolve] Module "node:fs" has been externalized for browser compatibility, imported by "src/data/neighborhoodPolygons.js".
```

Both modules carried a Node-only `fs` branch, only reachable under `node --test` (Node's loader requires an explicit import attribute for a JSON module that Vite doesn't need), alongside a Vite dynamic-JSON-import branch for the browser.

## Fix

A dynamic `import('./x.json', { with: { type: 'json' } })` works identically under Node's native loader and under Vite (dev + build, still its own lazy chunk) — Node 20.10+/22+ support the `with` import-attribute syntax natively. One loader for both environments, zero `node:fs` reference anywhere in either file, so there's nothing left for the browser build to externalize.

## Verification

`node --test` on both files' suites (20/20 pass), `npm run build` with the `node:fs externalized` warnings gone and the regions/marine/san-francisco JSON chunks still split out exactly as before (same sizes, still lazy — not folded into the eager bundle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)