### PR TITLE
test: normalise CRLF line endings in reasonableDefaults source anchors

### DIFF
--- a/src/reasonableDefaults.test.mjs
+++ b/src/reasonableDefaults.test.mjs
@@ -38,9 +38,17 @@ import {
 } from './scopeMask.js';
 import { ShareLinkManager } from './sharelink.js';
 
-const uiSource = fs.readFileSync(new URL('./ui.js', import.meta.url), 'utf8');
-const indexHtml = fs.readFileSync(new URL('../index.html', import.meta.url), 'utf8');
-const shareSource = fs.readFileSync(new URL('./sharelink.js', import.meta.url), 'utf8');
+/**
+ * Read a source file with line endings normalised to LF, so the `\n`-bearing
+ * anchors below match on a Windows checkout with `core.autocrlf=true` too.
+ */
+function readSource(relativePath) {
+  return fs.readFileSync(new URL(relativePath, import.meta.url), 'utf8').replace(/\r\n/g, '\n');
+}
+
+const uiSource = readSource('./ui.js');
+const indexHtml = readSource('../index.html');
+const shareSource = readSource('./sharelink.js');
 
 /** Slice ui.js between two literal anchors, so a pin reads one method, not the file. */
 function uiBlock(start, end) {


### PR DESCRIPTION
## What

`src/reasonableDefaults.test.mjs` reads `ui.js`, `index.html`, and
`sharelink.js` as text and slices them between literal anchors. The
`_applyGlobalPostDefaults` pin uses the end anchor `'\n  }\n'`, whose
newline is not at the end of the string. On a Windows checkout with
`core.autocrlf=true` those files use CRLF, so that substring is never
found and `uiBlock` fails with "missing source anchor". The result is
8/9 passing, with `detection-on-by-default is a default, not an operator
override` failing.

## Fix

Normalise `\r\n` to `\n` when reading the three source files, via a small
`readSource` helper. The anchors are all written with `\n`, so this makes
the pins independent of the checkout's line-ending style.

## Verification

- Converted `ui.js` / `index.html` / `sharelink.js` to CRLF locally and
  reproduced the exact failure from the issue.
- With this change, all 9 tests in the file pass under both CRLF and LF
  sources.
- `npm test` is green (2587 passing).

Fixes #88