### PR TITLE
fix: retry photorealistic 3D tiles via Cesium ion when Google returns the EEA 403

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,14 @@ of current runtime behavior, see [`docs/CURRENT-STATE.md`](docs/CURRENT-STATE.md
 
 ### Fixed
 
+- Photorealistic 3D tiles now load for EEA-billed Google projects. Google
+  returns a hard `403 PERMISSION_DENIED` on satellite and 3D tiles for projects
+  linked to a European Economic Area billing address (post 2025-07-08 EEA
+  terms); startup previously fell back to the flat globe. When the direct
+  request fails and a Cesium ion token is configured, the tileset is retried
+  through Cesium ion (asset 2275207), which serves the same Google
+  Photorealistic 3D Tiles under Cesium's own agreement. Without an ion token,
+  behavior is unchanged.
 - A missing optional FIRMS key no longer turns the complete Environmental
   mission into `LOAD FAILED`. The FIRMS row still reports `KEY REQUIRED`, while
   earthquakes continue to load. Real lifecycle and fetch failures retain

--- a/docs/CURRENT-STATE.md
+++ b/docs/CURRENT-STATE.md
@@ -1572,7 +1572,13 @@ Historical planning documents may not match runtime behavior.
 
 ## Runtime Stack
 
-- Vite + CesiumJS app with Google Photorealistic 3D Tiles
+- Vite + CesiumJS app with Google Photorealistic 3D Tiles. Startup loads the
+  tileset directly from Google; if that fails (EEA-billed Google projects get a
+  hard `403` on satellite/3D tiles under the post-2025-07-08 EEA terms) and a
+  Cesium ion token is configured, `Cesium.GoogleMaps.defaultApiKey` is cleared
+  and the load is retried through Cesium ion asset 2275207 — the same Google
+  tileset via Cesium's agreement. Only when both routes fail (or no ion token
+  exists) does the app fall back to the flat Cesium globe.
 - Scene/HUD/style systems in `src/ui.js` and `src/hud.js`
 - Layer management in `src/data/manager.js`
 - Map stack switching in `src/mapStackController.js`

--- a/src/main.js
+++ b/src/main.js
@@ -157,9 +157,23 @@ async function init() {
     let tileset = null;
     try {
       // Load Google Photorealistic 3D Tiles
-      tileset = await Cesium.createGooglePhotorealistic3DTileset({
-        onlyUsingWithGoogleGeocoder: true,
-      });
+      try {
+        tileset = await Cesium.createGooglePhotorealistic3DTileset({
+          onlyUsingWithGoogleGeocoder: true,
+        });
+      } catch (directError) {
+        // EEA-billed Google projects get a hard 403 on 3D tiles
+        // (developers.google.com/maps/comms/eea/map-tiles). Cesium ion serves
+        // the same tileset through Cesium's own agreement: clearing the key
+        // makes createGooglePhotorealistic3DTileset use ion asset 2275207,
+        // which needs only Ion.defaultAccessToken.
+        if (!Cesium.Ion.defaultAccessToken) throw directError;
+        console.warn('[Init] Direct Google 3D Tiles failed, retrying via Cesium ion:', directError);
+        Cesium.GoogleMaps.defaultApiKey = undefined;
+        tileset = await Cesium.createGooglePhotorealistic3DTileset({
+          onlyUsingWithGoogleGeocoder: true,
+        });
+      }
       viewer.scene.primitives.add(tileset);
       // NOTE: Cesium World Terrain intentionally disabled — conflicts with Google 3D Tiles at high zoom.
       // Google Photorealistic 3D Tiles provide their own terrain/elevation.


### PR DESCRIPTION
## What

Google Maps projects linked to a **European Economic Area billing address** get a hard `403 PERMISSION_DENIED` on satellite and 3D tiles under the [EEA terms effective 2025-07-08](https://developers.google.com/maps/comms/eea/map-tiles). For every EEA user, startup silently fell back to the flat Cesium globe — no photorealistic planet at all, with no key misconfiguration to fix on their side.

This patch keeps the direct Google load as the primary path. When it fails **and** a Cesium ion token is configured, it clears `Cesium.GoogleMaps.defaultApiKey` and retries `createGooglePhotorealistic3DTileset()`, which then streams the **same Google tileset** through Cesium ion asset 2275207 under Cesium's own agreement (1,000 root tiles/month on ion's free Community plan). Without an ion token, behavior is unchanged: the error propagates to the existing flat-globe fallback.

Also updates `CHANGELOG.md` and `docs/CURRENT-STATE.md` per CONTRIBUTING.

## How verified

On an actual EEA-billed setup (Iceland 🇮🇸):
- Reproduced the 403 at the API level: `POST tile.googleapis.com/v1/createSession` and `GET /v1/3dtiles/root.json` both return the documented EEA `PERMISSION_DENIED`.
- Verified the ion route end-to-end: `GET api.cesium.com/v1/assets/2275207/endpoint` → 200, and the Google root tileset it hands back loads fine.
- `npm run build` ✅ and `npm test` ✅ (2,587 pass / 0 fail).
- `npm run test:track`: 97 pass / 3 fail — the 3 failures are the harness's "no console errors" gates catching the **browser-emitted** network log of the initial 403 (`Failed to load resource: 403 … tile.googleapis.com`). That line is logged by Chrome itself before JS can handle the rejection, so it can't be suppressed from the app; it pre-exists this patch on EEA machines (the old code's failing boot logged the same error) and does not occur on non-EEA machines, where the suite should stay fully green. The run itself proves the fallback works: the share-link tests emit `map=photoreal`, i.e. the tileset was live via ion.

## Notes

- Fixes the misleading UX where EEA users see only the OSM/flat globe and reasonably assume their Google key is broken.
- If you'd rather avoid the one-time 403 console line on EEA machines, a follow-up could probe `createSession` once and cache the verdict, but that adds state for a cosmetic gain — kept this minimal instead.