### PR TITLE
feat: add OrcaRouter as a named provider for the AI HUD summary

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,6 +47,22 @@ OPENAI_REALTIME_REASONING_EFFORT=low
 OPENAI_REALTIME_CONTEXT_TOKENS=3000
 OPENAI_REALTIME_CONTEXT_RETENTION=0.5
 OPENAI_HUD_SUMMARY_MODEL=gpt-5-nano
+# Optional: point the OpenAI HUD summary upstream at any OpenAI-compatible
+# gateway (default https://api.openai.com/v1). Only the HUD summary path honors
+# this; Realtime voice always talks to api.openai.com directly.
+OPENAI_BASE_URL=
+# Optional: OrcaRouter (https://www.orcarouter.ai) as a named provider for the
+# AI HUD summary — an OpenAI-compatible gateway with its own model namespace
+# (model ids are namespaced, e.g. openai/gpt-4o-mini). To use it, set
+# ORCAROUTER_API_KEY and point the client at the OrcaRouter summary endpoint:
+#   VITE_HUD_SUMMARY_URL=/api/orcarouter/hud-summary
+# Leave VITE_HUD_SUMMARY_URL unset to keep using the OpenAI-backed summary.
+ORCAROUTER_API_KEY=
+ORCAROUTER_HUD_SUMMARY_MODEL=orcarouter/fusion-mini
+# Optional: opt-in per-IP rate limit for the OrcaRouter cost endpoint
+# (/api/orcarouter/hud-summary), in requests per minute. Same semantics as the
+# OpenAI limiter above; DEFAULT IS UNLIMITED.
+GEV_RATELIMIT_ORCAROUTER_PER_MIN=
 # Optional: opt-in per-IP rate limit for the OpenAI cost endpoints
 # (/api/realtime/token + /api/openai/hud-summary), in requests per minute.
 # DEFAULT IS UNLIMITED — unset (or 0) means no throttling, unchanged behavior.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ of current runtime behavior, see [`docs/CURRENT-STATE.md`](docs/CURRENT-STATE.md
 
 ### Added
 
+- Added OrcaRouter as a named provider for the AI HUD summary. Set `ORCAROUTER_API_KEY` and `VITE_HUD_SUMMARY_URL=/api/orcarouter/hud-summary` to route the five-word intelligence readout through the OrcaRouter gateway (an OpenAI-compatible `/v1/responses` upstream with its own namespaced model ids, default `orcarouter/fusion-mini`) instead of OpenAI. Voice still requires OpenAI.
+- Added an `OPENAI_BASE_URL` override so the OpenAI HUD summary path can target any OpenAI-compatible gateway, and a per-IP `GEV_RATELIMIT_ORCAROUTER_PER_MIN` limiter mirroring the OpenAI one.
 - Added honest aircraft identity narration: callsign, operator, registration,
   type, and route come only from selected-contact context, and missing operator,
   route, or type enrichment is named explicitly.

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ No account, no signup. The first-run card will offer to stage a mission for you 
 
 ## 🎙️ Talk to It
 
-> Voice needs an **OpenAI key**. Without one the entire app still runs — the mic button just reports voice is unavailable. The same key drives the **AI HUD summary**: a terse, five-word intelligence-style readout of the current view that regenerates as you move.
+> Voice needs an **OpenAI key**. Without one the entire app still runs — the mic button just reports voice is unavailable. The same key drives the **AI HUD summary**: a terse, five-word intelligence-style readout of the current view that regenerates as you move. Want the summary on a different provider? Point it at an OpenAI-compatible gateway with `VITE_HUD_SUMMARY_URL=/api/orcarouter/hud-summary` and an `ORCAROUTER_API_KEY` — see [API Keys](#-api-keys).
 
 Click **GEV MIC**, grant the microphone, and just talk. This is more than a voice-controlled remote:
 
@@ -289,6 +289,7 @@ Five keys cover the fully keyed experience. Three currently offer no-cost develo
 |---|-----|-----|--------|
 | 🔴 | **Google Maps** *(required)* | The photorealistic 3D planet ([Map Tiles API](https://developers.google.com/maps/documentation/tile)) | [Google Cloud Console](https://console.cloud.google.com/) — metered; [check current pricing](https://developers.google.com/maps/billing-and-pricing/pricing) and URL-restrict it |
 | 🔴 | **OpenAI** | 🎙️ The voice experience + AI HUD summary. Want another provider behind the mic? PRs welcome | [platform.openai.com](https://platform.openai.com) — metered; [check current API pricing](https://openai.com/api/pricing/) |
+| 🟡 | **OrcaRouter** *(optional)* | 🪧 The AI HUD summary on a different provider — an OpenAI-compatible gateway with its own model namespace. Drop in `ORCAROUTER_API_KEY` + `VITE_HUD_SUMMARY_URL=/api/orcarouter/hud-summary` (voice still needs OpenAI) | [orcarouter.ai](https://www.orcarouter.ai) |
 | 🟡 | **AISStream** | 🚢 Live global ships | [aisstream.io](https://aisstream.io) — free, seriously, it's a two-minute signup |
 | 🟡 | **NASA FIRMS** | 🔥 Live active fires | [firms.modaps.eosdis.nasa.gov](https://firms.modaps.eosdis.nasa.gov/api/map_key/) — free |
 | 🟡 | **TomTom** | 🚦 Real traffic instead of an approximate simulation | [developer.tomtom.com](https://developer.tomtom.com) — check the current developer allowance for your account |

--- a/docs/CURRENT-STATE.md
+++ b/docs/CURRENT-STATE.md
@@ -2272,6 +2272,7 @@ silently demoting every later lookup for the session.
 - GBFS response size is capped; CCTV health map is bounded.
 - Proxy error payloads are sanitized (no internal error details returned to clients).
 - `OPENAI_API_KEY` is server-side only; the browser receives ephemeral Realtime client secrets from `/api/realtime/token`.
+- `ORCAROUTER_API_KEY` is server-side only; the browser can point the AI HUD summary at `/api/orcarouter/hud-summary` (an OpenAI-compatible `/v1/responses` upstream, model namespaced via `ORCAROUTER_HUD_SUMMARY_MODEL`) instead of the default OpenAI-backed `/api/openai/hud-summary` by setting `VITE_HUD_SUMMARY_URL`.
 - `AISSTREAM_API_KEY` is server-side only; the browser reads the same-origin `/api/ais-live` cache.
 - `/api/google/nearby-places` keeps the Google key out of Places requests issued for voice scene context.
 - `/api/google/text-search` keeps the Google key server-side for view-biased Places recovery used by annotation resolution.

--- a/src/hud.js
+++ b/src/hud.js
@@ -34,7 +34,7 @@ const MILITARY_STYLES = new Set(['retro', 'surveillance', 'thermal']);
 /** Allowed HUD layout variants. */
 const HUD_VARIANTS = new Set(['tactical', 'operator', 'minimal']);
 const HUD_SUMMARY_INTERVAL_MS = 15000;
-const HUD_SUMMARY_URL = '/api/openai/hud-summary';
+const HUD_SUMMARY_URL = import.meta.env?.VITE_HUD_SUMMARY_URL || '/api/openai/hud-summary';
 
 /**
  * Cell size (degrees) for the ALT readout's geoid-undulation cache. N changes

--- a/vite.config.js
+++ b/vite.config.js
@@ -458,6 +458,21 @@ function googleRateLimiter() {
   if (_googleRateLimiter === undefined) _googleRateLimiter = makeOptInRateLimiter(process.env.GEV_RATELIMIT_GOOGLE_PER_MIN);
   return _googleRateLimiter;
 }
+let _orcarouterRateLimiter; // undefined = not built yet; null = unlimited; fn = active limiter
+/** OrcaRouter cost endpoint (hud-summary). Null = unlimited (default). */
+function orcarouterRateLimiter() {
+  if (_orcarouterRateLimiter === undefined) _orcarouterRateLimiter = makeOptInRateLimiter(process.env.GEV_RATELIMIT_ORCAROUTER_PER_MIN);
+  return _orcarouterRateLimiter;
+}
+
+/**
+ * OpenAI-compatible API base URL for the HUD summary upstream. Most setups use
+ * the default; the override exists so the summary path can be pointed at any
+ * OpenAI-compatible gateway without a code change.
+ */
+function openAiBaseUrl() {
+  return String(process.env.OPENAI_BASE_URL || 'https://api.openai.com/v1').replace(/\/+$/, '');
+}
 
 /**
  * Apply an opt-in limiter to a request, writing a 429 when over the cap.
@@ -1324,6 +1339,8 @@ const OPENAI_REALTIME_REASONING_DEFAULT = 'low';
 const OPENAI_REALTIME_CONTEXT_TOKENS_DEFAULT = 3000;
 const OPENAI_REALTIME_CONTEXT_RETENTION_DEFAULT = 0.5;
 const OPENAI_HUD_SUMMARY_MODEL_DEFAULT = 'gpt-5-nano';
+const ORCAROUTER_HUD_SUMMARY_MODEL_DEFAULT = 'orcarouter/fusion-mini';
+const ORCAROUTER_BASE_URL_DEFAULT = 'https://api.orcarouter.ai/v1';
 const REALTIME_DEBUG_LOG_DIR = path.join(__dirname, '.gev-logs');
 const REALTIME_DEBUG_LOG_FILE = path.join(REALTIME_DEBUG_LOG_DIR, 'realtime-conversations.jsonl');
 const REALTIME_DEBUG_LOG_MAX_BYTES = 8 * 1024 * 1024;
@@ -4981,7 +4998,7 @@ function openAiRealtimeProxy() {
       try {
         const body = await readRequestBody(req, 64 * 1024);
         const context = JSON.parse(body || '{}');
-        const response = await fetch('https://api.openai.com/v1/responses', {
+        const response = await fetch(`${openAiBaseUrl()}/responses`, {
           method: 'POST',
           headers: {
             Authorization: `Bearer ${apiKey}`,
@@ -5014,6 +5031,67 @@ function openAiRealtimeProxy() {
         res.statusCode = 502;
         res.setHeader('Content-Type', 'application/json');
         res.end(JSON.stringify({ error: error?.message || 'OpenAI HUD summary request failed' }));
+      }
+    });
+
+    middlewares.use('/api/orcarouter/hud-summary', async (req, res) => {
+      if (req.method !== 'POST') {
+        res.statusCode = 405;
+        res.setHeader('Content-Type', 'application/json');
+        res.end(JSON.stringify({ error: 'Method not allowed' }));
+        return;
+      }
+
+      // Opt-in per-IP throttle (GEV_RATELIMIT_ORCAROUTER_PER_MIN). No-op when unset.
+      if (!enforceOptInRateLimit(orcarouterRateLimiter(), req, res)) return;
+
+      const apiKey = process.env.ORCAROUTER_API_KEY;
+      if (!apiKey) {
+        res.statusCode = 503;
+        res.setHeader('Content-Type', 'application/json');
+        res.end(JSON.stringify({ error: 'ORCAROUTER_API_KEY is not set' }));
+        return;
+      }
+
+      try {
+        const body = await readRequestBody(req, 64 * 1024);
+        const context = JSON.parse(body || '{}');
+        // The /v1/responses shape matches OpenAI's Responses API, which is what
+        // the shared HUD summary parser below expects — only the upstream base
+        // URL, key, and model differ. See .env.example for the overrides.
+        const response = await fetch(`${ORCAROUTER_BASE_URL_DEFAULT}/responses`, {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${apiKey}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            model: process.env.ORCAROUTER_HUD_SUMMARY_MODEL || ORCAROUTER_HUD_SUMMARY_MODEL_DEFAULT,
+            instructions: [
+              "Write one concise intelligence-HUD summary for God's Eye View.",
+              'Use only the supplied place, street, nearby-place, and enabled-layer text labels.',
+              'Prefer the clearest named place and include a relevant enabled layer only when useful.',
+              'Do not infer from coordinates or invent a place.',
+              'Output exactly five words with no title, punctuation, markdown, or introductory phrase.',
+            ].join(' '),
+            input: JSON.stringify(context),
+            reasoning: { effort: 'minimal' },
+            max_output_tokens: 100,
+          }),
+        });
+        const data = await response.json().catch(() => ({}));
+        const summary = toFiveWordHudSummary(extractOpenAiResponseText(data));
+        res.statusCode = response.ok && summary ? 200 : response.status || 502;
+        res.setHeader('Content-Type', 'application/json; charset=utf-8');
+        res.setHeader('Cache-Control', 'no-store');
+        res.end(JSON.stringify({
+          summary: summary || null,
+          error: response.ok ? null : data.error?.message || 'OrcaRouter HUD summary request failed',
+        }));
+      } catch (error) {
+        res.statusCode = 502;
+        res.setHeader('Content-Type', 'application/json');
+        res.end(JSON.stringify({ error: error?.message || 'OrcaRouter HUD summary request failed' }));
       }
     });
 


### PR DESCRIPTION
## Add OrcaRouter as a named provider for the AI HUD summary

God's Eye View is a spy-satellite simulator that turns live public signals — flight transponders, ship beacons, seismographs, public cameras — into a photorealistic 3D globe you can talk to. Today the hands-free voice agent and the five-word intelligence HUD summary are both brokered server-side through OpenAI. This PR adds **OrcaRouter** as a first-class named provider for the HUD summary lane, completely parallel to the existing OpenAI wiring.

### What's wired where

The change mirrors the repo's existing OpenAI HUD summary plumbing (server-side `openAiRealtimeProxy()` in `vite.config.js` → `/api/openai/hud-summary`, consumed by `src/hud.js`) file by file:

| Existing OpenAI path | OrcaRouter parallel |
| --- | --- |
| `vite.config.js` → `middlewares.use('/api/openai/hud-summary')` | `vite.config.js` → `middlewares.use('/api/orcarouter/hud-summary')` |
| `OPENAI_API_KEY` + `OPENAI_HUD_SUMMARY_MODEL` (server-side only) | `ORCAROUTER_API_KEY` + `ORCAROUTER_HUD_SUMMARY_MODEL` (server-side only) |
| `https://api.openai.com/v1/responses` upstream | `https://api.orcarouter.ai/v1/responses` upstream |
| `GEV_RATELIMIT_OPENAI_PER_MIN` opt-in per-IP limiter | `GEV_RATELIMIT_ORCAROUTER_PER_MIN` opt-in per-IP limiter |
| `HUD_SUMMARY_URL` hardcoded to `/api/openai/hud-summary` in `src/hud.js` | `VITE_HUD_SUMMARY_URL` env override (default stays OpenAI) |

OrcaRouter is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding orcarouter as a first-class provider means this project's users can use that stack directly, without treating OrcaRouter as an anonymous custom base URL.

It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

Because OrcaRouter speaks the OpenAI Responses API (`/v1/responses`) for its models, the new endpoint reuses the repo's shared five-word summary parser (`extractOpenAiResponseText` + `toFiveWordHudSummary`) — only the upstream base URL, key, and namespaced model id differ. No parsing or client logic is duplicated.

### Verified

- `npm run build` — green.
- `npm test` — 2580 pass; the 2 failures (`aisWatchdogTransport.test.mjs`, `hudAltitudeDatum.test.mjs`) are pre-existing on a pristine checkout under this container's Node 20 runtime (the repo targets Node 24) and are untouched by this change.
- Live end-to-end: with `ORCAROUTER_API_KEY` set and the client pointed at `/api/orcarouter/hud-summary`, the dev server's new endpoint returned **HTTP 200** with a real five-word summary — `{"summary":"San Francisco United States flights","error":null}` — for a San Francisco view context. (Voice still needs OpenAI; this only changes the HUD summary provider.)

### Docs

`README.md` keys table, `.env.example`, `CHANGELOG.md`, and the `docs/CURRENT-STATE.md` proxy baseline were updated to match.

To use it: set `ORCAROUTER_API_KEY`, optionally pick a model via `ORCAROUTER_HUD_SUMMARY_MODEL` (default `orcarouter/fusion-mini`), and point the client at the new endpoint with `VITE_HUD_SUMMARY_URL=/api/orcarouter/hud-summary`.

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.
