### PR TITLE
fix(firms-proxy): force IPv4-first so FIRMS fetch works when IPv6 is unreachable (#68)

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -30,6 +30,7 @@ import { promises as fsp } from 'node:fs';
 import { createHash, randomUUID } from 'node:crypto';
 import path from 'node:path';
 import { Readable } from 'node:stream';
+import { setDefaultAutoSelectFamily } from 'node:net';
 import https from 'node:https';
 import { lookup as lookupDns } from 'node:dns/promises';
 import { directionToHeading } from './src/data/directionText.js';
@@ -1973,6 +1974,14 @@ function tomtomProxy() {
  * @returns {import('vite').Plugin}
  */
 function firmsProxy() {
+  // Fix #68: on Node 24, Happy Eyeballs can pick an unreachable IPv6 route to
+  // FIRMS (firms.modaps.eosdis.nasa.gov) when only IPv4 is available, so the
+  // proxy fails with `fetch failed` / ENETUNREACH even though curl -4 works.
+  // Force IPv4-first for the dev-server process. No-op on Node < 20.12.
+  if (typeof setDefaultAutoSelectFamily === 'function') {
+    try { setDefaultAutoSelectFamily(false); } catch { /* older Node: ignored */ }
+  }
+
   const TTL_MS = 30 * 60_000;
   const STATUS_TTL_MS = 5 * 60_000;
   const SOURCES = ['VIIRS_NOAA20_NRT', 'VIIRS_NOAA21_NRT', 'VIIRS_SNPP_NRT'];


### PR DESCRIPTION
## Summary
Fixes #68. On Node 24 the built-in `fetch()` uses Happy Eyeballs and can select an unreachable IPv6 route to `firms.modaps.eosdis.nasa.gov` when only IPv4 is available. The FIRMS proxy then fails with `fetch failed` / `ENETUNREACH` even though `curl -4` works and the key is valid.

Call `net.setDefaultAutoSelectFamily(false)` once when the FIRMS proxy initializes. This is the in-process equivalent of `node --no-network-family-autoselection` and forces IPv4-first for the dev-server process. Guarded in a try/catch so it's a no-op on Node < 20.12.

## Root cause
The reporter confirmed:
- `curl -4 https://firms.modaps.eosdis.nasa.gov/...` → HTTP 200
- `node -e "fetch('https://firms.modaps.eosdis.nasa.gov/')"` → `AggregateError [ETIMEDOUT]` with `ENETUNREACH 2001:4d0:241a:40c0::34:443`
- `node --no-network-family-autoselection -e "fetch(...)"` → works

The fix applies that same behavior from inside the dev server, so no CLI flag is required.

## Verification
- `node --check vite.config.js` passes
- `setDefaultAutoSelectFamily` is confirmed present and callable on Node 24 (`typeof net.setDefaultAutoSelectFamily === 'function'`)
- Change is scoped to `firmsProxy()` init; no behavior change when IPv6 is reachable

Fixes #68