### PR TITLE
release: v0.1.1 — installation and live-data fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ of current runtime behavior, see [`docs/CURRENT-STATE.md`](docs/CURRENT-STATE.md
 
 ## [Unreleased]
 
+## [0.1.1] — 2026-09-01 — Installation and live-data fixes
+
+### Changed
+
+- Tightened the README opening around keyless setup, source freshness, modeled
+  experiences, and the accessibility of the provider stack.
+
 ### Fixed
 
 - Pinokio now recognizes its nested successful-install marker, so a completed

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Photorealistic 3D globe. Live aircraft, ships, satellites, earthquakes, traffic,
 
 🏆 **#1 on GitHub Trending this past week — thank you.** You asked for a one-click install; it's here.
 
-⚡ **No keys, no signup, no config file.** One click through [Pinokio](https://pinokio.computer/) — or `npm install && npm run dev` — and the globe is live: real aircraft, real satellites, real cameras. Keys are power-ups you paste into the app later. **[→ Quick Start](#-quick-start)**
+⚡ **No keys, no signup, no config file.** One click through [Pinokio](https://pinokio.computer/) — or `npm install && npm run dev` — and the globe comes to life. Keys are power-ups you paste into the app later. **[→ Quick Start](#-quick-start)**
 
 </div>
 
@@ -42,10 +42,13 @@ Most open-source intelligence is a pile of browser tabs. The signals are abundan
 
 > Half the magic is that it looks like a forbidden cockpit. The other half is that every line of code is inspectable.
 
-Most feeds are live; explicitly labeled traffic, camera-pose, and launch
-experiences may be simulated, estimated, or reconstructed.
+Most feeds are live or regularly refreshed. Traffic is simulated along real
+roads using aggregate location data. CCTV camera poses and rocket launch
+trajectories are coarse estimates.
 
-And it's honest about money: the best free and nearly-free APIs give you the real experience out of the box — then it's yours to extend with bigger, more expensive data sources whenever you're ready.
+You'll be surprised how accessible this is. Free and nearly-free APIs deliver
+a surprisingly complete experience out of the box — then it's yours to extend
+with bigger data sources whenever you're ready.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gods-eye-view",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gods-eye-view",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@mapbox/vector-tile": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gods-eye-view",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A real-time intelligence console for planet Earth — photorealistic 3D globe, live aircraft/ships/satellites/earthquakes/CCTV, and hands-free voice control. Runs in a browser.",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## What ships in v0.1.1

- Keep all three VIIRS source batches in Active Fires when record counts exceed the engine's argument limit.
- Measure GBFS response caps in bytes, including multi-byte upstream payloads.
- Keep keyless `dev-fresh.sh` working on stock macOS Bash 3.2.
- Recognize completed Pinokio installs so the launcher exposes Start instead of returning to Install.
- Tighten the README opening and clarify which experiences are live, refreshed, simulated, or estimated.

## Verification

- `npm run doctor -- --json`: ready
- `npm test`: 2675 passed, 0 failed, 1 intentional Node-version skip
- `npm run build`: passed
- `npm run test:track`: 108 passed, 0 failed
- Private CI: Node 24.14, Node 26.x, and Windows onboarding passed

## Community

Thank you to:

- @yangsongsf for the Active Fires fix in #93.
- @prajwal-raj for the GBFS byte-limit fix in #45.
- @manjunath22466 for the Pinokio lifecycle fix and real-device validation carried by #152.

Their contributor credit is preserved on `main` and in this release.
