### PR TITLE
fix: isolate ACL verify PowerShell from pwsh7-polluted PSModulePath

### DIFF
--- a/src/keySetupHardening.mjs
+++ b/src/keySetupHardening.mjs
@@ -143,6 +143,19 @@ export function hardenCredentialFile(filepath, {
     // accept only three explicit FullControl allow principals, with inheritance
     // disabled. Any unexpected rule, right, command error, or missing principal
     // fails closed before the secret reaches disk.
+    //
+    // The verify process must load Microsoft.PowerShell.Security (Get-Acl)
+    // from the Windows PowerShell system module tree ONLY. A side-by-side
+    // PowerShell 7 install prepends its own module trees to PSModulePath at
+    // startup; inherited into a 5.1 process, the incompatible 7.x manifest
+    // cannot be autoloaded and the verify step fails. Reset PSModulePath to
+    // the 5.1 system tree derived from the already-validated executable path —
+    // the same fail-closed posture that refuses PATH-shadowed tools above.
+    // Nothing an inheriting environment prepends may steer Get-Acl.
+    const powershellModuleDirectory = path.win32.join(
+      path.win32.dirname(tools.powershell),
+      'Modules',
+    );
     const verified = spawn(tools.powershell, [
       '-NoProfile',
       '-NonInteractive',
@@ -152,6 +165,7 @@ export function hardenCredentialFile(filepath, {
         ...environment,
         GEV_ACL_FILE: filepath,
         GEV_ACL_USER_SID: sid,
+        PSModulePath: powershellModuleDirectory,
       },
       stdio: 'ignore',
       windowsHide: true,

--- a/src/keySetupHardening.test.mjs
+++ b/src/keySetupHardening.test.mjs
@@ -126,6 +126,47 @@ test('Windows hardening applies and then verifies the exact restricted DACL', ()
   assert.match(calls[2].args.at(-1), /seen\.Count -ne 3/);
 });
 
+test('Windows hardening isolates the verify PowerShell from a pwsh7-polluted PSModulePath', () => {
+  const calls = [];
+  // Exactly what a side-by-side PowerShell 7 install prepends at startup:
+  // its own user Documents\PowerShell, Program Files\PowerShell, and
+  // Program Files\PowerShell\7 module trees all shadow the 5.1 system path.
+  const pollutedModulePath = [
+    'C:\\Users\\alice\\Documents\\PowerShell\\Modules',
+    'C:\\Program Files\\PowerShell\\Modules',
+    'c:\\program files\\powershell\\7\\Modules',
+    'C:\\Program Files\\WindowsPowerShell\\Modules',
+    'C:\\WINDOWS\\system32\\WindowsPowerShell\\v1.0\\Modules',
+  ].join(';');
+  const result = hardenCredentialFile('C:\\GEV\\ENVIRONMENT.tmp', {
+    platform: 'win32',
+    environment: {
+      SYSTEMROOT: WINDOWS_ROOT,
+      PSModulePath: pollutedModulePath,
+    },
+    fileSystem: windowsFileSystem(),
+    spawn(command, args, options) {
+      calls.push({ command, args, options });
+      if (command.endsWith('\\whoami.exe')) {
+        return { status: 0, signal: null, stdout: `"WORKSTATION\\alice","${USER_SID}"\r\n` };
+      }
+      return { status: 0, signal: null };
+    },
+  });
+  assert.equal(result, true);
+  const verify = calls.find(({ command }) => command.endsWith('powershell.exe'));
+  assert.ok(verify, 'the ACL verify powershell must be spawned');
+  const modulePath = verify.options.env.PSModulePath;
+  // Fail closed: the verification interpreter must never inherit pwsh7's
+  // module trees — a 7.x Microsoft.PowerShell.Security manifest cannot be
+  // autoloaded by 5.1, and an untrusted tree must not shadow Get-Acl at all.
+  assert.ok(!/Documents\\PowerShell\\Modules/i.test(modulePath), 'user pwsh7 module tree must be stripped');
+  assert.ok(!/Program Files\\PowerShell\\Modules/i.test(modulePath), 'Program Files pwsh7 module tree must be stripped');
+  assert.ok(!/Program Files\\PowerShell\\7\\Modules/i.test(modulePath), 'pwsh7 install module tree must be stripped');
+  // ... but the 5.1 system module directory (where Get-Acl lives) must remain.
+  assert.match(modulePath, /System32\\WindowsPowerShell\\v1\.0\\Modules/i);
+});
+
 test('Windows hardening bypasses PATH-shadowed native ACL tools', () => {
   const commands = [];
   const result = hardenCredentialFile('D:\\GEV\\ENVIRONMENT.tmp', {


### PR DESCRIPTION
## Summary

On Windows machines with a side-by-side **PowerShell 7** install, the credential-file hardening step (`hardenCredentialFile` in `src/keySetupHardening.mjs`) fails closed and refuses to write provider keys.

### Root cause

PowerShell 7 prepends its own module trees to `PSModulePath` at startup:
```
C:\Users\<user>\Documents\PowerShell\Modules
C:\Program Files\PowerShell\Modules
c:\program files\powershell\7\Modules
...
```
The Windows hardening path spawns the **system PowerShell 5.1** (`powershell.exe`) to verify the exact DACL of the credential file. That process inherited the polluted `PSModulePath` from the caller. When 5.1 tried to autoload `Get-Acl` (from `Microsoft.PowerShell.Security`), it hit the incompatible **7.x module manifest** first and failed with `CouldNotAutoloadMatchingModule`:

```
Get-Acl : 找不到模块"Microsoft.PowerShell.Security"中的 Get-Acl 命令...
```

`hardenCredentialFile` returns `false` → provider settings refuse to save any key on such machines. This is also a **security gap**: the verify interpreter must never load modules from an environment an untrusted caller can steer.

### Fix

Reset `PSModulePath` for the **verify subprocess only** to the 5.1 system module tree, derived from the already-validated `powershell.exe` path (`<systemRoot>\System32\WindowsPowerShell\v1.0\Modules`). This matches the file's existing fail-closed posture toward inheritable environment steering (the same reasoning that refuses `PATH`-shadowed tools and redirected system roots). No other environment is touched, and the surrounding `environment` spread is preserved.

### Test

New regression test `Windows hardening isolates the verify PowerShell from a pwsh7-polluted PSModulePath` simulates a polluted `PSModulePath` and asserts the verify subprocess receives only the 5.1 system module tree.

Verified locally on Windows:
- `src/keySetupHardening.test.mjs`: **13/13 pass**, including the real-DACL integration test (`Windows production hardener applies its exact DACL with native tools`), which previously failed on this machine.
- Full suite: **exit 0** (2677 tests).