### PR TITLE
fix(launches): preserve unknown payload details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Earthquake refreshes validate the complete feed and construct replacement entiti
 
 Non-object or array-valued properties reject the response instead of being treated as an unknown magnitude.
 
+Launch payloads with missing records now say PAYLOAD DATA UNAVAILABLE. Missing names use Unnamed payload; absent or invalid mass stays unknown instead of appearing as 0 KG.
+
 This changelog records public product changes. For the authoritative description
 of current runtime behavior, see [`docs/CURRENT-STATE.md`](docs/CURRENT-STATE.md).
 

--- a/docs/CURRENT-STATE.md
+++ b/docs/CURRENT-STATE.md
@@ -6,6 +6,8 @@ Earthquake refreshes validate the complete feed and construct replacement entiti
 
 Non-object or array-valued properties reject the response instead of being treated as an unknown magnitude.
 
+Launch payloads with missing records now say PAYLOAD DATA UNAVAILABLE. Missing names use Unnamed payload; absent or invalid mass stays unknown instead of appearing as 0 KG.
+
 Updated: August 24, 2026
 
 ## Installations and map-source guidance

--- a/src/data/rocketLaunches.js
+++ b/src/data/rocketLaunches.js
@@ -2106,13 +2106,15 @@ function normalizePayloadFlights(launch) {
     const payload = flight.payload || flight;
     return {
       id: String(flight.id || payload.id || `payload-${index}`),
-      name: payload.name || flight.name || 'Undisclosed payload',
+      name: payload.name || flight.name || 'Unnamed payload',
       type: payload.type?.name || flight.type?.name || null,
       manufacturer: payload.manufacturer?.name || null,
       operator: payload.operator?.name || null,
       destination: flight.destination || payload.destination || null,
       amount: Number.isFinite(Number(flight.amount)) ? Number(flight.amount) : 1,
-      massKg: Number.isFinite(Number(payload.mass)) ? Number(payload.mass) : null,
+      massKg: (typeof payload.mass === 'number' || (typeof payload.mass === 'string' && payload.mass.trim() !== ''))
+        && Number.isFinite(Number(payload.mass)) && Number(payload.mass) >= 0
+        ? Number(payload.mass) : null,
     };
   });
 }
@@ -2288,7 +2290,7 @@ function renderMissionPanel() {
   _missionPanel.querySelector('[data-mission-payloads]').innerHTML = missionTableRows(
     payloadRows,
     3,
-    'CLASSIFIED / MULTI-PAYLOAD',
+    'PAYLOAD DATA UNAVAILABLE',
   );
   const stageRows = launch.recoveryStages.map((stage) => {
     const endpoint = stage.endpoint;

--- a/src/data/rocketLaunches.test.mjs
+++ b/src/data/rocketLaunches.test.mjs
@@ -1253,3 +1253,16 @@ test('disable reports a semantic failure while restoring the satellites dependen
     /could not restore the satellites layer/,
   );
 });
+
+
+test('missing payload details stay unknown without inventing mass or classification', () => {
+  for (const [mass, expected] of [[null, null], [undefined, null], ['', null], ['  ', null],
+    [false, null], [-1, null], ['invalid', null], [0, 0], ['125', 125]]) {
+    const [launch] = normalizeRocketLaunches([{ id: 'mass', pad: { latitude: 1, longitude: 2 }, net: '2026-07-20T10:00:00Z',
+      payloads: [{ mass }] }], NOW);
+    assert.equal(launch.payloads[0].massKg, expected);
+    assert.equal(launch.payloads[0].name, 'Unnamed payload');
+  }
+  const [launch] = normalizeRocketLaunches([{ id: 'missing', pad: { latitude: 1, longitude: 2 }, net: '2026-07-20T10:00:00Z' }], NOW);
+  assert.deepEqual(launch.payloads, []);
+});


### PR DESCRIPTION
Missing launch payload records currently display “CLASSIFIED / MULTI-PAYLOAD,” and a null mass is coerced to 0 KG. Use “PAYLOAD DATA UNAVAILABLE” and “Unnamed payload,” and preserve missing or invalid mass as null while retaining explicit zero and numeric values.

Adds normalization regressions for null, absent, blank, boolean, negative, invalid, zero and numeric-string mass values. The regression fails against unchanged main.

Validation: full unit suites on Node 26.4.0 and 24.14.0, including the Node 24 allocation checks, and production build using main's package-lock dependencies. The Windows-only test is skipped on macOS; Node 26's allocation checks are intentionally skipped and exercised on Node 24.

Follow-up browser validation on this exact commit: `npm run doctor -- --json` passed; `npm run test:track` against a running localhost dev server passed 108/108 with no failures or skips. A focused visible-Chrome smoke test verified the actual Space Missions panel with synthetic records: absent payloads show PAYLOAD DATA UNAVAILABLE, and an unnamed payload with null mass does not display 0 KG. Screenshots were inspected.

The initial tracking attempt ran without a working dev server and timed out; the successful run above supersedes that setup failure. GitHub CI has not reported checks yet; no CI result is claimed.
