### PR TITLE
docs: add main CI badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 # 🌐 God's Eye View
 
+[![CI](https://github.com/bilawalsidhu/gods-eye-view/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/bilawalsidhu/gods-eye-view/actions/workflows/ci.yml)
+
 ### A spy-satellite simulator in your browser — then you realize the sources are public and the data is real.
 
 Photorealistic 3D globe. Live aircraft, ships, satellites, earthquakes, traffic, and public cameras. Hands-free voice control powered by a realtime AI agent.


### PR DESCRIPTION
Add the live main-branch CI badge directly below the README title, linking to the workflow runs. The rest of the README is byte-for-byte unchanged. Verified the exact diff and whitespace; CI will run the existing checks.