### PR TITLE
chore(issues): add issue forms and disable blank issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -6,7 +6,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for the report. Issues without reproduction steps and logs get closed, so please fill in every required field. Redact API keys before pasting anything.
+        Thanks for the report. Reproduction steps and relevant errors help us investigate. If installation failed before you could run a command, say which command failed and why. Redact API keys, tokens, and personal information; do not paste your .env file.
   - type: textarea
     id: what
     attributes:
@@ -39,6 +39,7 @@ body:
     id: env
     attributes:
       label: OS, Node version, browser
+      description: Include the versions you can find. Write "unknown" for anything unavailable.
       placeholder: "Windows 11, Node 24.14.0, Chrome 151"
     validations:
       required: true
@@ -46,7 +47,7 @@ body:
     id: commit
     attributes:
       label: Version or commit
-      description: Output of `git rev-parse --short HEAD`, or the release tag.
+      description: Output of `git rev-parse --short HEAD`, or the release tag. If unavailable, say when you installed or last updated.
       placeholder: "aacfa06"
     validations:
       required: true
@@ -54,7 +55,7 @@ body:
     id: doctor
     attributes:
       label: Output of `npm run doctor`
-      description: It reports which providers are configured without printing key values.
+      description: Run this in the app directory. It reports which providers are configured without printing key values. If it cannot run, describe the failure instead.
       render: text
     validations:
       required: true
@@ -62,7 +63,7 @@ body:
     id: logs
     attributes:
       label: Server log and browser console
-      description: Terminal output from the dev server (or the Pinokio log) plus browser console errors. Redact keys.
+      description: Paste the relevant error lines from the terminal or Pinokio log and browser console. If no log is available, explain what prevented it. Redact credentials and personal information.
       render: text
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,68 @@
+name: Bug report
+description: Something is broken, fails to install, or renders wrong.
+title: "bug: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the report. Issues without reproduction steps and logs get closed, so please fill in every required field. Redact API keys before pasting anything.
+  - type: textarea
+    id: what
+    attributes:
+      label: What happened
+      description: What you did, what you expected, and what you saw instead.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Fresh clone, `npm ci`, `npm run dev`
+        2. Open http://localhost:4173, click LOCATION, type "London"
+        3. See "Search failed" toast
+    validations:
+      required: true
+  - type: dropdown
+    id: install
+    attributes:
+      label: How you installed
+      options:
+        - Pinokio one-click
+        - Terminal (git clone + npm)
+        - Docker
+        - Other (say what in the description)
+    validations:
+      required: true
+  - type: input
+    id: env
+    attributes:
+      label: OS, Node version, browser
+      placeholder: "Windows 11, Node 24.14.0, Chrome 151"
+    validations:
+      required: true
+  - type: input
+    id: commit
+    attributes:
+      label: Version or commit
+      description: Output of `git rev-parse --short HEAD`, or the release tag.
+      placeholder: "aacfa06"
+    validations:
+      required: true
+  - type: textarea
+    id: doctor
+    attributes:
+      label: Output of `npm run doctor`
+      description: It reports which providers are configured without printing key values.
+      render: text
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Server log and browser console
+      description: Terminal output from the dev server (or the Pinokio log) plus browser console errors. Redact keys.
+      render: text
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/bilawalsidhu/gods-eye-view/security/advisories/new
+    about: Report anything exploitable privately. Do not open a public issue for it.
+  - name: Setup and quick start
+    url: https://github.com/bilawalsidhu/gods-eye-view#readme
+    about: Install paths (Pinokio, terminal), provider keys, and what runs keyless.
+  - name: Known issues
+    url: https://github.com/bilawalsidhu/gods-eye-view/blob/main/docs/KNOWN-ISSUES.md
+    about: Check here before filing. Your problem may already be tracked with a workaround.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,39 @@
+name: Feature request
+description: Propose a new layer, data source, tool, or UI capability.
+title: "feat: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        The project only ships public data with a license that allows redistribution, and it does not build features for identifying or tracking individuals. Read the "Responsible & Open" section of the README before proposing a data source.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What can you not do today, and who needs it?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposal
+      description: What should it do? Keep the first version small.
+    validations:
+      required: true
+  - type: textarea
+    id: source
+    attributes:
+      label: Data source, license, and attribution
+      description: For anything that shows data, link the feed or API, name its license, and say whether it works without a key. Write "none" for pure UI changes.
+    validations:
+      required: true
+  - type: dropdown
+    id: contribute
+    attributes:
+      label: Will you build it?
+      options:
+        - Yes, I plan to open a PR
+        - No, this is a request for someone else
+    validations:
+      required: true


### PR DESCRIPTION
Adds bug-report and feature-request forms, disables blank issues, and links setup, known issues, and private vulnerability reporting.

Bug reports collect reproduction steps, installation method, version, doctor output, and relevant errors. People whose installation fails can explain unavailable diagnostics instead of being blocked by commands they cannot run. The form asks reporters to redact credentials and personal information and avoid posting their `.env` file. Feature requests collect the problem, proposed change, and data-source licensing and attribution.

Validation: all three files parse as YAML; field IDs, required fields, dropdown values, contact links, repository paths, and existing bug/enhancement labels checked. Bilawal’s original commit is preserved, with a follow-up clarifying installation-failure reports.
