### PR TITLE
fix(search): cancel active lookup when controls are disposed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ of current runtime behavior, see [`docs/CURRENT-STATE.md`](docs/CURRENT-STATE.md
 
 ## [Unreleased]
 
+- Cancel the active location lookup when its controls are disposed.
+
+
 ### Fixed
 
 - GBFS rejects upstream redirects, caps streamed responses at 5 MiB, and keeps

--- a/docs/CURRENT-STATE.md
+++ b/docs/CURRENT-STATE.md
@@ -2513,7 +2513,7 @@ Only valid answers and definitive misses enter bounded caches; malformed replies
 HTTP refusals and outages remain retryable. Searches share a 12-second total
 deadline, with Photon requests capped at six seconds each. Caller/application
 cancellation stops retries and late cache writes. Replacing a location search
-cancels the previous lookup. Photon uses a soft proximity bias, up to five
+cancels the previous lookup; disposing its controls cancels the active lookup. Photon uses a soft proximity bias, up to five
 candidates, and an unbiased retry for name mismatches. Invalid/wrapped bounds
 are omitted rather than framing the wrong part of the globe.
 

--- a/src/cameraHandoff.test.mjs
+++ b/src/cameraHandoff.test.mjs
@@ -412,9 +412,3 @@ test('vessel and fire layers announce valid clicks and never fly cameras', () =>
     'selectAndFocusFire(carded)',
   ], 'fire sibling ownership');
 });
-
-
-test('disposal aborts the active location lookup', () => {
-  const disposal = ui.slice(ui.indexOf('  async dispose()'));
-  assert.match(disposal, /this\._locationSearchController\?\.abort\(\)/);
-});

--- a/src/cameraHandoff.test.mjs
+++ b/src/cameraHandoff.test.mjs
@@ -412,3 +412,9 @@ test('vessel and fire layers announce valid clicks and never fly cameras', () =>
     'selectAndFocusFire(carded)',
   ], 'fire sibling ownership');
 });
+
+
+test('disposal aborts the active location lookup', () => {
+  const disposal = ui.slice(ui.indexOf('  async dispose()'));
+  assert.match(disposal, /this\._locationSearchController\?\.abort\(\)/);
+});

--- a/src/ui.js
+++ b/src/ui.js
@@ -4236,7 +4236,6 @@ export class StyleManager {
     };
     if (panelId === 'control-panel') {
       this._cancelMapSourceFocus?.();
-    this._locationSearchController?.abort();
       this._cancelMapSourceFocus = cancelMapSourceFocus;
     }
 
@@ -10319,6 +10318,7 @@ export class StyleManager {
     this._globalStatusNotice = null;
     if (this._globalLoadingStatus) this._globalLoadingStatus.hidden = true;
     this._disposed = true;
+    this._locationSearchController?.abort();
     this._cancelMapSourceFocus?.();
     // Revoke persistence/hash authority before teardown can emit manager changes.
     this._layerStateCoordinator?.destroy();


### PR DESCRIPTION
Move active location-search cancellation from panel initialization to control disposal. This completes the teardown wiring introduced in #166; provider selection and search results are unchanged.

Validation: existing teardown assertions, full unit suite, setup doctor, formatting, production build and browser disposal/tracking checks. CI must pass before merge.
